### PR TITLE
Add SmolVLM model and tests

### DIFF
--- a/models/smolVLM/__init__.py
+++ b/models/smolVLM/__init__.py
@@ -1,0 +1,10 @@
+"""Minimal SmolVLM building blocks exposed as a small Python package."""
+from .config import SmolVLMConfig, SmolVLMVisionConfig, SmolVLMLanguageConfig
+from .model import SmolVLM
+
+__all__ = [
+    "SmolVLMConfig",
+    "SmolVLMVisionConfig",
+    "SmolVLMLanguageConfig",
+    "SmolVLM",
+]

--- a/models/smolVLM/config.py
+++ b/models/smolVLM/config.py
@@ -1,0 +1,137 @@
+"""Configuration objects describing the SmolVLM architecture."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, TYPE_CHECKING
+
+from models.smolLM2 import SmolLM2Config
+
+if TYPE_CHECKING:  # pragma: no cover - only for type checkers
+    from transformers import Idefics3Config
+
+
+@dataclass
+class SmolVLMVisionConfig:
+    """Hyper-parameters for the SigLIP-style vision transformer."""
+
+    image_size: int
+    patch_size: int
+    num_channels: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    layer_norm_eps: float = 1e-6
+    attention_dropout: float = 0.0
+    hidden_act: str = "gelu_pytorch_tanh"
+
+    @property
+    def num_patches_per_side(self) -> int:
+        return self.image_size // self.patch_size
+
+    @property
+    def num_patches(self) -> int:
+        side = self.num_patches_per_side
+        return side * side
+
+
+@dataclass
+class SmolVLMLanguageConfig:
+    """Subset of LLaMA-style parameters used by the language decoder."""
+
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    max_position_embeddings: int
+    rope_theta: float
+    rms_norm_eps: float
+    dropout: float = 0.0
+    tie_embeddings: bool = False
+    pad_token_id: int = 0
+
+    def to_smol_lm_config(self) -> SmolLM2Config:
+        return SmolLM2Config(
+            vocab_size=self.vocab_size,
+            d_model=self.hidden_size,
+            n_layers=self.num_hidden_layers,
+            n_heads=self.num_attention_heads,
+            n_kv_heads=self.num_key_value_heads,
+            d_ff=self.intermediate_size,
+            max_seq_len=self.max_position_embeddings,
+            rope_theta=self.rope_theta,
+            dropout=self.dropout,
+            norm_eps=self.rms_norm_eps,
+            tie_embeddings=self.tie_embeddings,
+            pad_token_id=self.pad_token_id,
+        )
+
+
+@dataclass
+class SmolVLMConfig:
+    """Bundle of vision + language parameters plus VL glue settings."""
+
+    vision: SmolVLMVisionConfig
+    language: SmolVLMLanguageConfig
+    image_token_id: int
+    pad_token_id: int
+    scale_factor: int = 1
+    mm_hidden_size: Optional[int] = None
+
+    @classmethod
+    def from_hf_config(cls, hf_cfg: "Idefics3Config") -> "SmolVLMConfig":
+        """Create a SmolVLMConfig from a Hugging Face Idefics3Config."""
+
+        vision_cfg = hf_cfg.vision_config
+        text_cfg = hf_cfg.text_config
+
+        vision = SmolVLMVisionConfig(
+            image_size=int(getattr(vision_cfg, "image_size", 0) or vision_cfg.size["longest_edge"]),
+            patch_size=int(vision_cfg.patch_size),
+            num_channels=int(vision_cfg.num_channels),
+            hidden_size=int(vision_cfg.hidden_size),
+            intermediate_size=int(vision_cfg.intermediate_size),
+            num_hidden_layers=int(vision_cfg.num_hidden_layers),
+            num_attention_heads=int(vision_cfg.num_attention_heads),
+            layer_norm_eps=float(vision_cfg.layer_norm_eps),
+            attention_dropout=float(getattr(vision_cfg, "attention_dropout", 0.0)),
+            hidden_act=str(getattr(vision_cfg, "hidden_act", "gelu_pytorch_tanh")),
+        )
+
+        language = SmolVLMLanguageConfig(
+            vocab_size=int(text_cfg.vocab_size),
+            hidden_size=int(text_cfg.hidden_size),
+            intermediate_size=int(text_cfg.intermediate_size),
+            num_hidden_layers=int(text_cfg.num_hidden_layers),
+            num_attention_heads=int(text_cfg.num_attention_heads),
+            num_key_value_heads=int(getattr(text_cfg, "num_key_value_heads", text_cfg.num_attention_heads)),
+            max_position_embeddings=int(text_cfg.max_position_embeddings),
+            rope_theta=float(getattr(text_cfg, "rope_theta", 100000.0)),
+            rms_norm_eps=float(getattr(text_cfg, "rms_norm_eps", 1e-5)),
+            dropout=float(getattr(text_cfg, "attention_dropout", 0.0)),
+            tie_embeddings=bool(getattr(hf_cfg, "tie_word_embeddings", getattr(text_cfg, "tie_word_embeddings", False))),
+            pad_token_id=int(getattr(text_cfg, "pad_token_id", getattr(hf_cfg, "pad_token_id", 0) or 0)),
+        )
+
+        scale_factor = int(getattr(hf_cfg, "scale_factor", getattr(text_cfg, "pixel_shuffle_factor", 1)))
+        mm_hidden = getattr(hf_cfg, "mm_hidden_size", None)
+        if mm_hidden is not None:
+            mm_hidden = int(mm_hidden)
+
+        pad_id = int(getattr(hf_cfg, "pad_token_id", language.pad_token_id))
+        return cls(
+            vision=vision,
+            language=language,
+            image_token_id=int(getattr(hf_cfg, "image_token_id", 0)),
+            pad_token_id=pad_id,
+            scale_factor=max(scale_factor, 1),
+            mm_hidden_size=mm_hidden,
+        )
+
+    def to_language_config(self) -> SmolLM2Config:
+        cfg = self.language.to_smol_lm_config()
+        cfg.pad_token_id = self.pad_token_id
+        return cfg
+

--- a/models/smolVLM/model.py
+++ b/models/smolVLM/model.py
@@ -1,0 +1,344 @@
+"""Combined vision-language model closely tracking the SmolVLM layout."""
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from models.smolLM2 import SmolLM2
+
+from .config import SmolVLMConfig
+from .projector import SmolVLMMultiModalProjector
+from .vision import SmolVLMVisionEncoder
+
+
+class SmolVLM(nn.Module):
+    """Minimal reproduction of the SmolVLM architecture."""
+
+    def __init__(self, cfg: SmolVLMConfig) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.vision_encoder = SmolVLMVisionEncoder(cfg.vision)
+        vision_dim = cfg.vision.hidden_size * (cfg.scale_factor ** 2)
+        self.mm_projector = SmolVLMMultiModalProjector(
+            vision_dim=vision_dim,
+            text_dim=cfg.language.hidden_size,
+            scale_factor=cfg.scale_factor,
+            hidden_dim=cfg.mm_hidden_size,
+        )
+        self.language_model = SmolLM2(cfg.to_language_config())
+        # Initialise the vision + projector layers with the same Gaussian scheme as the text model.
+        self.vision_encoder.apply(self._init_weights)
+        self.mm_projector.apply(self._init_weights)
+
+    @staticmethod
+    def _init_weights(module: nn.Module) -> None:
+        if isinstance(module, (nn.Linear, nn.Conv2d)):
+            nn.init.normal_(module.weight, mean=0.0, std=0.02)
+            if module.bias is not None:
+                nn.init.zeros_(module.bias)
+
+    # --------------------------------------------------------------------- utils
+    def num_parameters(self, trainable_only: bool = False) -> int:
+        params = self.parameters() if not trainable_only else (p for p in self.parameters() if p.requires_grad)
+        return sum(p.numel() for p in params)
+
+    # ------------------------------------------------------------------- features
+    def get_image_features(
+        self,
+        pixel_values: torch.Tensor,
+        pixel_attention_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Encode images into the language embedding space."""
+
+        batch, num_images, channels, height, width = pixel_values.shape
+        dtype = self.language_model.tok_emb.weight.dtype
+        device = pixel_values.device
+
+        flat_pixels = pixel_values.to(dtype=dtype).view(batch * num_images, channels, height, width)
+        nb_values_per_image = flat_pixels.shape[1:].numel()
+        real_images_mask = (flat_pixels == 0.0).sum(dim=(-1, -2, -3)) != nb_values_per_image
+        flat_pixels = flat_pixels[real_images_mask].contiguous()
+
+        if pixel_attention_mask is None:
+            pixel_attention_mask = torch.ones(
+                size=(flat_pixels.size(0), height, width),
+                dtype=torch.bool,
+                device=device,
+            )
+        else:
+            pixel_attention_mask = pixel_attention_mask.view(batch * num_images, *pixel_attention_mask.shape[2:])
+            pixel_attention_mask = pixel_attention_mask[real_images_mask].contiguous()
+
+        if flat_pixels.numel() == 0:
+            return torch.zeros((0, 0, self.cfg.language.hidden_size), device=device, dtype=dtype)
+
+        patch_size = self.cfg.vision.patch_size
+        patches = pixel_attention_mask.unfold(1, patch_size, patch_size).unfold(2, patch_size, patch_size)
+        patch_attention_mask = (patches.sum(dim=(-1, -2)) > 0)
+
+        vision_hidden = self.vision_encoder(flat_pixels, patch_attention_mask=patch_attention_mask)
+        projected = self.mm_projector(vision_hidden)
+        return projected.to(dtype=dtype)
+
+    def _merge_image_embeddings(
+        self,
+        input_ids: torch.Tensor,
+        inputs_embeds: torch.Tensor,
+        image_hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        if image_hidden_states.numel() == 0:
+            return inputs_embeds
+        image_hidden_states = image_hidden_states.to(device=inputs_embeds.device, dtype=inputs_embeds.dtype)
+        special_mask = (input_ids == self.cfg.image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
+        if int(special_mask.sum().item()) != image_hidden_states.numel():
+            raise ValueError("Mismatch between number of <image> tokens and image hidden states")
+        merged = inputs_embeds.masked_scatter(special_mask, image_hidden_states.reshape(-1))
+        return merged.view_as(inputs_embeds)
+
+    def _run_language_model(
+        self,
+        inputs_embeds: torch.Tensor,
+        *,
+        attention_mask: Optional[torch.Tensor],
+        position_ids: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        batch, seq_len, _ = inputs_embeds.shape
+        attn_mask, pos_ids = self.language_model._prepare_attention_inputs(
+            attention_mask,
+            position_ids,
+            batch=batch,
+            seq_len=seq_len,
+            device=inputs_embeds.device,
+        )
+        hidden_states = self.language_model.dropout(inputs_embeds)
+        for block in self.language_model.blocks:
+            hidden_states = block(hidden_states, attn_mask=attn_mask, position_ids=pos_ids)
+        hidden_states = self.language_model.norm_out(hidden_states)
+        return self.language_model.lm_head(hidden_states)
+
+    # -------------------------------------------------------------------- forward
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        *,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        pixel_values: Optional[torch.Tensor] = None,
+        pixel_attention_mask: Optional[torch.Tensor] = None,
+        image_hidden_states: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if image_hidden_states is not None and pixel_values is not None:
+            raise ValueError("Provide either pixel_values or precomputed image_hidden_states, not both")
+        if image_hidden_states is None and pixel_values is not None:
+            image_hidden_states = self.get_image_features(pixel_values, pixel_attention_mask)
+
+        inputs_embeds = self.language_model.tok_emb(input_ids)
+        if image_hidden_states is not None:
+            inputs_embeds = self._merge_image_embeddings(input_ids, inputs_embeds, image_hidden_states)
+        return self._run_language_model(inputs_embeds, attention_mask=attention_mask, position_ids=position_ids)
+
+    # ------------------------------------------------------------------- sampling
+    @torch.no_grad()
+    def generate(
+        self,
+        input_ids: torch.Tensor,
+        *,
+        pixel_values: Optional[torch.Tensor] = None,
+        pixel_attention_mask: Optional[torch.Tensor] = None,
+        max_new_tokens: int = 50,
+        temperature: float = 1.0,
+        top_k: Optional[int] = None,
+    ) -> torch.Tensor:
+        self.eval()
+        image_hidden_states = None
+        if pixel_values is not None:
+            image_hidden_states = self.get_image_features(pixel_values, pixel_attention_mask)
+        generated = input_ids
+        for _ in range(max_new_tokens):
+            logits = self(
+                generated,
+                image_hidden_states=image_hidden_states,
+            )[:, -1, :]
+            logits = logits / max(temperature, 1e-6)
+            if top_k is not None:
+                values, _ = torch.topk(logits, min(top_k, logits.size(-1)))
+                thresh = values[:, [-1]]
+                logits = logits.masked_fill(logits < thresh, -float("inf"))
+            probs = F.softmax(logits, dim=-1)
+            next_id = torch.multinomial(probs, num_samples=1)
+            generated = torch.cat([generated, next_id], dim=1)
+        return generated
+
+    # --------------------------------------------------------------------- loading
+    def load_hf_state_dict(
+        self,
+        hf_state: Dict[str, torch.Tensor],
+        *,
+        strict: bool = False,
+        verbose: bool = True,
+        dtype: Optional[torch.dtype] = None,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        ref_param = next(self.parameters(), None)
+        if dtype is None:
+            dtype = ref_param.dtype if ref_param is not None else torch.float32
+        if device is None:
+            device = ref_param.device if ref_param is not None else torch.device("cpu")
+
+        used_keys = set()
+        missing = []
+        mismatched = []
+
+        params = dict(self.named_parameters())
+        buffers = dict(self.named_buffers())
+
+        def fetch(*names: str, mark_only: bool = False) -> Optional[torch.Tensor]:
+            for name in names:
+                if name in hf_state:
+                    used_keys.add(name)
+                    if mark_only:
+                        return None
+                    return hf_state[name].to(device=device, dtype=dtype)
+            return None
+
+        def assign(target_name: str, value: Optional[torch.Tensor]) -> None:
+            if value is None:
+                missing.append(target_name)
+                return
+            target = params.get(target_name)
+            if target is None:
+                target = buffers.get(target_name)
+            if target is None:
+                missing.append(target_name)
+                return
+            if tuple(target.shape) != tuple(value.shape):
+                mismatched.append((target_name, tuple(target.shape), tuple(value.shape)))
+                return
+            target.data.copy_(value)
+
+        # --- resolve prefixes -------------------------------------------------
+        state_keys = list(hf_state.keys())
+
+        def prefix_for(candidates):
+            for prefix in candidates:
+                if any(key.startswith(prefix) for key in state_keys):
+                    return prefix
+            return None
+
+        vision_prefix = prefix_for([
+            "model.vision_model",
+            "vision_model",
+        ])
+        projector_prefix = prefix_for([
+            "model.connector.modality_projection",
+            "connector.modality_projection",
+            "model.multi_modal_projector",
+            "multi_modal_projector",
+        ])
+        text_prefix = prefix_for([
+            "model.language_model.model",
+            "model.text_model",
+            "language_model.model",
+            "text_model",
+        ])
+
+        # --- vision embeddings ------------------------------------------------
+        if vision_prefix:
+            assign("vision_encoder.patch_embed.weight", fetch(f"{vision_prefix}.embeddings.patch_embedding.weight"))
+            assign("vision_encoder.patch_embed.bias", fetch(f"{vision_prefix}.embeddings.patch_embedding.bias"))
+            assign("vision_encoder.pos_embed", fetch(f"{vision_prefix}.embeddings.position_embedding.weight"))
+            cls_token = fetch(f"{vision_prefix}.embeddings.class_embedding")
+            if cls_token is not None:
+                assign("vision_encoder.cls_token", cls_token)
+            assign("vision_encoder.ln_post.weight", fetch(f"{vision_prefix}.post_layernorm.weight"))
+            assign("vision_encoder.ln_post.bias", fetch(f"{vision_prefix}.post_layernorm.bias"))
+
+            for idx in range(len(self.vision_encoder.blocks)):
+                block = f"vision_encoder.blocks.{idx}"
+                assign(f"{block}.ln1.weight", fetch(f"{vision_prefix}.encoder.layers.{idx}.layer_norm1.weight"))
+                assign(f"{block}.ln1.bias", fetch(f"{vision_prefix}.encoder.layers.{idx}.layer_norm1.bias"))
+                assign(f"{block}.ln2.weight", fetch(f"{vision_prefix}.encoder.layers.{idx}.layer_norm2.weight"))
+                assign(f"{block}.ln2.bias", fetch(f"{vision_prefix}.encoder.layers.{idx}.layer_norm2.bias"))
+
+                assign(f"{block}.attn.q_proj.weight", fetch(f"{vision_prefix}.encoder.layers.{idx}.self_attn.q_proj.weight"))
+                assign(f"{block}.attn.q_proj.bias", fetch(f"{vision_prefix}.encoder.layers.{idx}.self_attn.q_proj.bias"))
+                assign(f"{block}.attn.k_proj.weight", fetch(f"{vision_prefix}.encoder.layers.{idx}.self_attn.k_proj.weight"))
+                assign(f"{block}.attn.k_proj.bias", fetch(f"{vision_prefix}.encoder.layers.{idx}.self_attn.k_proj.bias"))
+                assign(f"{block}.attn.v_proj.weight", fetch(f"{vision_prefix}.encoder.layers.{idx}.self_attn.v_proj.weight"))
+                assign(f"{block}.attn.v_proj.bias", fetch(f"{vision_prefix}.encoder.layers.{idx}.self_attn.v_proj.bias"))
+                assign(f"{block}.attn.o_proj.weight", fetch(f"{vision_prefix}.encoder.layers.{idx}.self_attn.out_proj.weight"))
+                assign(f"{block}.attn.o_proj.bias", fetch(f"{vision_prefix}.encoder.layers.{idx}.self_attn.out_proj.bias"))
+
+                assign(f"{block}.mlp.fc1.weight", fetch(f"{vision_prefix}.encoder.layers.{idx}.mlp.fc1.weight"))
+                assign(f"{block}.mlp.fc1.bias", fetch(f"{vision_prefix}.encoder.layers.{idx}.mlp.fc1.bias"))
+                assign(f"{block}.mlp.fc2.weight", fetch(f"{vision_prefix}.encoder.layers.{idx}.mlp.fc2.weight"))
+                assign(f"{block}.mlp.fc2.bias", fetch(f"{vision_prefix}.encoder.layers.{idx}.mlp.fc2.bias"))
+
+        # --- projector --------------------------------------------------------
+        if projector_prefix:
+            if hasattr(self.mm_projector, "proj"):
+                assign("mm_projector.proj.weight", fetch(f"{projector_prefix}.proj.weight", f"{projector_prefix}.linear_2.weight"))
+                bias = fetch(f"{projector_prefix}.proj.bias", f"{projector_prefix}.linear_2.bias")
+                if bias is not None:
+                    assign("mm_projector.proj.bias", bias)
+            else:
+                assign("mm_projector.linear1.weight", fetch(f"{projector_prefix}.linear_1.weight"))
+                assign("mm_projector.linear1.bias", fetch(f"{projector_prefix}.linear_1.bias"))
+                assign("mm_projector.linear2.weight", fetch(f"{projector_prefix}.linear_2.weight"))
+                assign("mm_projector.linear2.bias", fetch(f"{projector_prefix}.linear_2.bias"))
+
+        # --- language ---------------------------------------------------------
+        if text_prefix:
+            assign("language_model.tok_emb.weight", fetch(f"{text_prefix}.embed_tokens.weight"))
+            assign("language_model.norm_out.weight", fetch(f"{text_prefix}.norm.weight", f"{text_prefix}.model.norm.weight"))
+
+            for idx in range(len(self.language_model.blocks)):
+                block = f"language_model.blocks.{idx}"
+                assign(f"{block}.ln_attn.weight", fetch(f"{text_prefix}.layers.{idx}.input_layernorm.weight"))
+                assign(f"{block}.ln_mlp.weight", fetch(f"{text_prefix}.layers.{idx}.post_attention_layernorm.weight"))
+
+                assign(f"{block}.attn.q_proj.weight", fetch(f"{text_prefix}.layers.{idx}.self_attn.q_proj.weight"))
+                assign(f"{block}.attn.k_proj.weight", fetch(f"{text_prefix}.layers.{idx}.self_attn.k_proj.weight"))
+                assign(f"{block}.attn.v_proj.weight", fetch(f"{text_prefix}.layers.{idx}.self_attn.v_proj.weight"))
+                assign(f"{block}.attn.o_proj.weight", fetch(f"{text_prefix}.layers.{idx}.self_attn.o_proj.weight"))
+
+                gate = fetch(f"{text_prefix}.layers.{idx}.mlp.gate_proj.weight", f"{text_prefix}.layers.{idx}.mlp.w1.weight")
+                up = fetch(f"{text_prefix}.layers.{idx}.mlp.up_proj.weight", f"{text_prefix}.layers.{idx}.mlp.w3.weight")
+                combined = fetch(f"{text_prefix}.layers.{idx}.mlp.fc1.weight")
+                mlp_in = self._stack_gate_up(gate, up, combined)
+                assign(f"{block}.mlp.in_proj.weight", mlp_in)
+                assign(f"{block}.mlp.out_proj.weight", fetch(f"{text_prefix}.layers.{idx}.mlp.down_proj.weight", f"{text_prefix}.layers.{idx}.mlp.w2.weight"))
+
+            assign("language_model.lm_head.weight", fetch("lm_head.weight", "model.lm_head.weight"))
+
+        unused = [key for key in hf_state if key not in used_keys]
+        if verbose:
+            print(f"[load_hf] copied tensors: {len(used_keys)}")
+            if missing:
+                print(f"[load_hf] missing target params: {len(missing)} (up to 10) -> {missing[:10]}")
+            if mismatched:
+                print(f"[load_hf] shape mismatches: {len(mismatched)} (first) -> {mismatched[0]}")
+            if unused:
+                print(f"[load_hf] unused source tensors: {len(unused)} (up to 10) -> {unused[:10]}")
+
+        if strict and (missing or mismatched):
+            raise RuntimeError("[load_hf strict] missing or mismatched parameters")
+
+    @staticmethod
+    def _stack_gate_up(
+        gate: Optional[torch.Tensor],
+        up: Optional[torch.Tensor],
+        combined: Optional[torch.Tensor],
+    ) -> Optional[torch.Tensor]:
+        if gate is not None and up is not None:
+            return torch.cat([gate, up], dim=0)
+        return combined
+
+    # ---------------------------------------------------------------- factory
+    @staticmethod
+    def from_config_dict(cfg_dict: Dict) -> "SmolVLM":
+        return SmolVLM(SmolVLMConfig(**cfg_dict))
+

--- a/models/smolVLM/projector.py
+++ b/models/smolVLM/projector.py
@@ -1,0 +1,50 @@
+"""Utilities for mapping vision features into the language space."""
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class SmolVLMMultiModalProjector(nn.Module):
+    """Pixel-shuffle followed by a small MLP to match the text dimension."""
+
+    def __init__(self, *, vision_dim: int, text_dim: int, scale_factor: int, hidden_dim: Optional[int] = None) -> None:
+        super().__init__()
+        self.scale_factor = max(scale_factor, 1)
+        self.hidden_dim = hidden_dim
+        self.out_features = text_dim
+        if hidden_dim is None:
+            self.proj = nn.Linear(vision_dim, text_dim, bias=False)
+        else:
+            self.linear1 = nn.Linear(vision_dim, hidden_dim, bias=True)
+            self.linear2 = nn.Linear(hidden_dim, text_dim, bias=True)
+
+    def forward(self, image_hidden_states: torch.Tensor) -> torch.Tensor:
+        if image_hidden_states.numel() == 0:
+            return image_hidden_states.new_zeros((0, 0, self.out_features))
+
+        shuffled = self.pixel_shuffle(image_hidden_states, self.scale_factor)
+        if self.hidden_dim is None:
+            return self.proj(shuffled)
+        hidden = F.silu(self.linear1(shuffled))
+        return self.linear2(hidden)
+
+    @staticmethod
+    def pixel_shuffle(x: torch.Tensor, scale_factor: int) -> torch.Tensor:
+        if scale_factor <= 1:
+            return x
+        batch, seq_len, dim = x.shape
+        side = int(seq_len ** 0.5)
+        if side * side != seq_len:
+            raise ValueError(f"Sequence length {seq_len} is not a perfect square; cannot pixel-shuffle.")
+        if side % scale_factor != 0:
+            raise ValueError("Scale factor must divide the patch grid size")
+        new_side = side // scale_factor
+        x = x.view(batch, side, side, dim)
+        x = x.reshape(batch, new_side, scale_factor, new_side, scale_factor, dim)
+        x = x.permute(0, 1, 3, 2, 4, 5).contiguous()
+        x = x.reshape(batch, new_side * new_side, dim * (scale_factor ** 2))
+        return x

--- a/models/smolVLM/vision.py
+++ b/models/smolVLM/vision.py
@@ -1,0 +1,165 @@
+"""Vision encoder mirroring the SmolVLM SigLIP backbone."""
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .config import SmolVLMVisionConfig
+
+
+def gelu_pytorch_tanh(x: torch.Tensor) -> torch.Tensor:
+    """Implementation of the tanh-approximated GELU used by SigLIP."""
+
+    return 0.5 * x * (1.0 + torch.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * x.pow(3))))
+
+
+def get_activation(name: str):
+    if name == "gelu" or name == "gelu_new":
+        return F.gelu
+    if name == "gelu_pytorch_tanh":
+        return gelu_pytorch_tanh
+    raise ValueError(f"Unsupported activation: {name}")
+
+
+class SmolVLMVisionAttention(nn.Module):
+    """Standard multi-head self-attention for the vision transformer."""
+
+    def __init__(self, cfg: SmolVLMVisionConfig) -> None:
+        super().__init__()
+        self.num_heads = cfg.num_attention_heads
+        self.head_dim = cfg.hidden_size // cfg.num_attention_heads
+        if self.head_dim * self.num_heads != cfg.hidden_size:
+            raise ValueError("hidden_size must be divisible by num_attention_heads")
+
+        self.q_proj = nn.Linear(cfg.hidden_size, cfg.hidden_size, bias=True)
+        self.k_proj = nn.Linear(cfg.hidden_size, cfg.hidden_size, bias=True)
+        self.v_proj = nn.Linear(cfg.hidden_size, cfg.hidden_size, bias=True)
+        self.o_proj = nn.Linear(cfg.hidden_size, cfg.hidden_size, bias=True)
+        self.dropout = nn.Dropout(cfg.attention_dropout)
+
+    def forward(self, hidden_states: torch.Tensor, attn_mask: Optional[torch.Tensor]) -> torch.Tensor:
+        batch, seq_len, hidden = hidden_states.shape
+        query = self.q_proj(hidden_states).view(batch, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+        key = self.k_proj(hidden_states).view(batch, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+        value = self.v_proj(hidden_states).view(batch, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+
+        mask = None
+        if attn_mask is not None:
+            neg_inf = torch.finfo(hidden_states.dtype).min
+            mask = (~attn_mask).to(dtype=hidden_states.dtype) * neg_inf
+            mask = mask.unsqueeze(1).unsqueeze(2)
+
+        attn_out = F.scaled_dot_product_attention(
+            query,
+            key,
+            value,
+            attn_mask=mask,
+            dropout_p=self.dropout.p if self.training else 0.0,
+            is_causal=False,
+        )
+        attn_out = attn_out.transpose(1, 2).contiguous().view(batch, seq_len, hidden)
+        return self.o_proj(attn_out)
+
+
+class SmolVLMVisionMLP(nn.Module):
+    """Feed-forward network used inside each vision transformer block."""
+
+    def __init__(self, cfg: SmolVLMVisionConfig) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(cfg.hidden_size, cfg.intermediate_size, bias=True)
+        self.fc2 = nn.Linear(cfg.intermediate_size, cfg.hidden_size, bias=True)
+        self.activation = get_activation(cfg.hidden_act)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.fc1(hidden_states)
+        hidden_states = self.activation(hidden_states)
+        return self.fc2(hidden_states)
+
+
+class SmolVLMVisionBlock(nn.Module):
+    """Pre-norm transformer block for the vision encoder."""
+
+    def __init__(self, cfg: SmolVLMVisionConfig) -> None:
+        super().__init__()
+        self.ln1 = nn.LayerNorm(cfg.hidden_size, eps=cfg.layer_norm_eps)
+        self.attn = SmolVLMVisionAttention(cfg)
+        self.ln2 = nn.LayerNorm(cfg.hidden_size, eps=cfg.layer_norm_eps)
+        self.mlp = SmolVLMVisionMLP(cfg)
+
+    def forward(self, hidden_states: torch.Tensor, attn_mask: Optional[torch.Tensor]) -> torch.Tensor:
+        attn_input = self.ln1(hidden_states)
+        hidden_states = hidden_states + self.attn(attn_input, attn_mask)
+        mlp_input = self.ln2(hidden_states)
+        return hidden_states + self.mlp(mlp_input)
+
+
+class SmolVLMVisionEncoder(nn.Module):
+    """Minimal SigLIP-style encoder used by SmolVLM."""
+
+    def __init__(self, cfg: SmolVLMVisionConfig) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.patch_embed = nn.Conv2d(cfg.num_channels, cfg.hidden_size, kernel_size=cfg.patch_size, stride=cfg.patch_size)
+        self.pos_embed = nn.Parameter(torch.zeros(cfg.num_patches, cfg.hidden_size))
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, cfg.hidden_size))  # kept for checkpoint compatibility
+        self.blocks = nn.ModuleList([SmolVLMVisionBlock(cfg) for _ in range(cfg.num_hidden_layers)])
+        self.ln_post = nn.LayerNorm(cfg.hidden_size, eps=cfg.layer_norm_eps)
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        patch_attention_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        batch = pixel_values.size(0)
+        device = pixel_values.device
+
+        if patch_attention_mask is None:
+            h = pixel_values.shape[2] // self.cfg.patch_size
+            w = pixel_values.shape[3] // self.cfg.patch_size
+            patch_attention_mask = torch.ones((batch, h, w), dtype=torch.bool, device=device)
+
+        hidden_states = self.patch_embed(pixel_values)
+        hidden_states = hidden_states.flatten(2).transpose(1, 2)
+
+        position_ids = self._build_position_ids(patch_attention_mask)
+        pos_embeds = F.embedding(position_ids, self.pos_embed)
+        hidden_states = hidden_states + pos_embeds
+
+        attn_mask = patch_attention_mask.view(batch, -1)
+        for block in self.blocks:
+            hidden_states = block(hidden_states, attn_mask)
+        return self.ln_post(hidden_states)
+
+    def _build_position_ids(self, patch_mask: torch.Tensor) -> torch.Tensor:
+        batch, h, w = patch_mask.shape
+        device = patch_mask.device
+        dtype = torch.float32
+        boundaries = torch.arange(
+            1 / self.cfg.num_patches_per_side,
+            1.0,
+            1 / self.cfg.num_patches_per_side,
+            device=device,
+            dtype=dtype,
+        )
+        position_ids = torch.zeros(batch, h * w, dtype=torch.long, device=device)
+        for batch_idx, mask in enumerate(patch_mask):
+            valid_flat = mask.view(-1)
+            if not torch.any(valid_flat):
+                continue
+            patches_h = int(mask[:, 0].sum().item())
+            patches_w = int(mask[0].sum().item())
+            if patches_h == 0 or patches_w == 0:
+                continue
+            frac_h = torch.arange(patches_h, device=device, dtype=dtype)
+            frac_w = torch.arange(patches_w, device=device, dtype=dtype)
+            frac_h = frac_h / max(patches_h, 1) * (1.0 - 1e-6)
+            frac_w = frac_w / max(patches_w, 1) * (1.0 - 1e-6)
+            bucket_h = torch.bucketize(frac_h, boundaries, right=True)
+            bucket_w = torch.bucketize(frac_w, boundaries, right=True)
+            pos = (bucket_h[:, None] * self.cfg.num_patches_per_side + bucket_w).reshape(-1)
+            position_ids[batch_idx, valid_flat] = pos[: int(valid_flat.sum().item())]
+        return position_ids

--- a/test/smolVLM/README.md
+++ b/test/smolVLM/README.md
@@ -1,0 +1,17 @@
+# SmolVLM Test Utilities
+
+These scripts mirror the SmolLM helpers but target the multimodal SmolVLM
+checkpoints.  They are intentionally lightweight, providing parity checks and
+quick sampling for the minimal implementation in `models/smolVLM/`.
+
+## Scripts
+
+- `compare_hf_vs_local.py` — downloads a Hugging Face SmolVLM checkpoint,
+  maps the weights into the local implementation, and runs a greedy
+  teacher-forced comparison for a text+image prompt.
+- `generate_smoke.py` — loads the weights and produces a short generated
+  response to a tiny text+image input.
+
+By default the scripts target `HuggingFaceTB/SmolVLM-256M-Base`, which is
+public.  Pass `--hf-model` to point at private or fine-tuned variants such as
+`HuggingFaceTB/SmolVLM2-256M-Video-Instruct` once you have access to them.

--- a/test/smolVLM/compare_hf_vs_local.py
+++ b/test/smolVLM/compare_hf_vs_local.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Parity check between the minimal SmolVLM and Hugging Face's reference model."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+from typing import Optional
+
+from PIL import Image
+import torch
+from transformers import AutoConfig, AutoModelForVision2Seq, AutoProcessor
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from models.smolVLM import SmolVLM, SmolVLMConfig  # noqa: E402
+
+DEFAULT_PROMPT = "Describe the image in one short sentence."
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--hf-model", default="HuggingFaceTB/SmolVLM-256M-Base")
+    p.add_argument("--revision", default=None)
+    p.add_argument("--device", default="cuda", choices=["cuda", "cpu"])
+    p.add_argument("--dtype", default="float32", choices=["float32", "float16", "bfloat16"])
+    p.add_argument("--steps", type=int, default=8, help="#teacher-forced decode steps to compare")
+    p.add_argument("--tol", type=float, default=2e-3, help="max allowed abs diff on logits")
+    p.add_argument("--prompt", default=None, help="override default prompt text")
+    p.add_argument("--image", default=None, help="path to an RGB image (defaults to a grey square)")
+    p.add_argument("--local-files-only", action="store_true")
+    p.add_argument("--trust-remote-code", action="store_true")
+    return p.parse_args()
+
+
+def build_prompt(processor: AutoProcessor, text: str) -> str:
+    bos = processor.tokenizer.bos_token or ""
+    image_token = getattr(processor, "image_token", "<image>")
+    terminator = processor.tokenizer.unk_token or ""
+    return f"{bos}User:{image_token}{text}{terminator}Assistant:"
+
+
+def load_image(path: Optional[str]) -> Image.Image:
+    if path is None:
+        return Image.new("RGB", (512, 512), color=(128, 128, 128))
+    return Image.open(path).convert("RGB")
+
+
+def main() -> None:
+    args = parse_args()
+    device = torch.device(args.device if (args.device == "cpu" or torch.cuda.is_available()) else "cpu")
+    dtype = {"float32": torch.float32, "float16": torch.float16, "bfloat16": torch.bfloat16}[args.dtype]
+
+    hf_cfg = AutoConfig.from_pretrained(
+        args.hf_model,
+        revision=args.revision,
+        local_files_only=args.local_files_only,
+        trust_remote_code=args.trust_remote_code,
+    )
+    processor = AutoProcessor.from_pretrained(
+        args.hf_model,
+        revision=args.revision,
+        local_files_only=args.local_files_only,
+        trust_remote_code=args.trust_remote_code,
+    )
+
+    prompt_text = args.prompt if args.prompt is not None else DEFAULT_PROMPT
+    prompt = build_prompt(processor, prompt_text)
+    image = load_image(args.image)
+    proc_inputs = processor(
+        text=[prompt],
+        images=[image],
+        padding=True,
+        return_tensors="pt",
+    )
+
+    input_ids = proc_inputs["input_ids"].to(device)
+    attention_mask = proc_inputs["attention_mask"].to(device)
+    pixel_values = proc_inputs["pixel_values"].to(device=device, dtype=dtype)
+    pixel_attention_mask = proc_inputs["pixel_attention_mask"].to(device)
+
+    smol_cfg = SmolVLMConfig.from_hf_config(hf_cfg)
+    local_model = SmolVLM(smol_cfg).to(device=device, dtype=dtype).eval()
+
+    hf_model = AutoModelForVision2Seq.from_pretrained(
+        args.hf_model,
+        revision=args.revision,
+        local_files_only=args.local_files_only,
+        trust_remote_code=args.trust_remote_code,
+        torch_dtype=dtype,
+        device_map={"": device.type},
+    ).eval()
+
+    local_model.load_hf_state_dict(hf_model.state_dict(), strict=False, verbose=True, dtype=dtype, device=device)
+
+    ids = input_ids.clone()
+    attn = attention_mask.clone()
+    for step in range(args.steps):
+        with torch.no_grad():
+            local_logits = local_model(
+                ids,
+                attention_mask=attn,
+                pixel_values=pixel_values,
+                pixel_attention_mask=pixel_attention_mask,
+            )[:, -1, :]
+            hf_out = hf_model(
+                input_ids=ids,
+                attention_mask=attn,
+                pixel_values=pixel_values,
+                pixel_attention_mask=pixel_attention_mask,
+            )
+            hf_logits = hf_out.logits[:, -1, :]
+        max_diff = (local_logits - hf_logits).abs().max().item()
+        print(f"[step {step}] max|Δlogits| = {max_diff:.6f}")
+        if max_diff > args.tol:
+            raise AssertionError(f"Logit mismatch at step {step}: {max_diff} > tol={args.tol}")
+        next_id = torch.argmax(hf_logits, dim=-1, keepdim=True)
+        ids = torch.cat([ids, next_id], dim=1)
+        attn = torch.cat([attn, attn.new_ones((attn.size(0), 1))], dim=1)
+
+    decoded = processor.tokenizer.decode(ids[0], skip_special_tokens=True)
+    print("\n=== PROMPT TEXT ===\n" + prompt_text)
+    print("\n=== LOCAL (teacher-forced path) ===\n" + decoded)
+    print("\nOK: logits matched within tolerance at each step.")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/smolVLM/generate_smoke.py
+++ b/test/smolVLM/generate_smoke.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Quick smoke-test generation for the minimal SmolVLM implementation."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+from typing import Optional
+
+from PIL import Image
+import torch
+from transformers import AutoConfig, AutoModelForVision2Seq, AutoProcessor
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from models.smolVLM import SmolVLM, SmolVLMConfig  # noqa: E402
+
+DEFAULT_PROMPT = "Summarise the scene in a few words."
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--hf-model", default="HuggingFaceTB/SmolVLM-256M-Base")
+    p.add_argument("--revision", default=None)
+    p.add_argument("--device", default="cuda", choices=["cuda", "cpu"])
+    p.add_argument("--dtype", default="float16", choices=["float32", "float16", "bfloat16"])
+    p.add_argument("--max-new-tokens", type=int, default=32)
+    p.add_argument("--temperature", type=float, default=0.8)
+    p.add_argument("--top-k", type=int, default=None)
+    p.add_argument("--prompt", default=None)
+    p.add_argument("--image", default=None, help="path to an RGB image (defaults to a grey square)")
+    p.add_argument("--local-files-only", action="store_true")
+    p.add_argument("--trust-remote-code", action="store_true")
+    return p.parse_args()
+
+
+def build_prompt(processor: AutoProcessor, text: str) -> str:
+    bos = processor.tokenizer.bos_token or ""
+    image_token = getattr(processor, "image_token", "<image>")
+    terminator = processor.tokenizer.unk_token or ""
+    return f"{bos}User:{image_token}{text}{terminator}Assistant:"
+
+
+def load_image(path: Optional[str]) -> Image.Image:
+    if path is None:
+        return Image.new("RGB", (512, 512), color=(180, 180, 180))
+    return Image.open(path).convert("RGB")
+
+
+def main() -> None:
+    args = parse_args()
+    device = torch.device(args.device if (args.device == "cpu" or torch.cuda.is_available()) else "cpu")
+    dtype = {"float32": torch.float32, "float16": torch.float16, "bfloat16": torch.bfloat16}[args.dtype]
+
+    hf_cfg = AutoConfig.from_pretrained(
+        args.hf_model,
+        revision=args.revision,
+        local_files_only=args.local_files_only,
+        trust_remote_code=args.trust_remote_code,
+    )
+    processor = AutoProcessor.from_pretrained(
+        args.hf_model,
+        revision=args.revision,
+        local_files_only=args.local_files_only,
+        trust_remote_code=args.trust_remote_code,
+    )
+
+    prompt_text = args.prompt if args.prompt is not None else DEFAULT_PROMPT
+    prompt = build_prompt(processor, prompt_text)
+    image = load_image(args.image)
+    proc_inputs = processor(
+        text=[prompt],
+        images=[image],
+        padding=True,
+        return_tensors="pt",
+    )
+
+    input_ids = proc_inputs["input_ids"].to(device)
+    attention_mask = proc_inputs["attention_mask"].to(device)
+    pixel_values = proc_inputs["pixel_values"].to(device=device, dtype=dtype)
+    pixel_attention_mask = proc_inputs["pixel_attention_mask"].to(device)
+
+    smol_cfg = SmolVLMConfig.from_hf_config(hf_cfg)
+    local_model = SmolVLM(smol_cfg).to(device=device, dtype=dtype).eval()
+    hf_model = AutoModelForVision2Seq.from_pretrained(
+        args.hf_model,
+        revision=args.revision,
+        local_files_only=args.local_files_only,
+        trust_remote_code=args.trust_remote_code,
+        torch_dtype=dtype,
+        device_map={"": device.type},
+    ).eval()
+
+    local_model.load_hf_state_dict(hf_model.state_dict(), strict=False, verbose=True, dtype=dtype, device=device)
+
+    with torch.no_grad():
+        local_ids = local_model.generate(
+            input_ids,
+            pixel_values=pixel_values,
+            pixel_attention_mask=pixel_attention_mask,
+            max_new_tokens=args.max_new_tokens,
+            temperature=args.temperature,
+            top_k=args.top_k,
+        )
+        hf_ids = hf_model.generate(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            pixel_values=pixel_values,
+            pixel_attention_mask=pixel_attention_mask,
+            max_new_tokens=args.max_new_tokens,
+            temperature=args.temperature,
+            top_k=args.top_k,
+        )
+
+    print("=== Prompt ===")
+    print(prompt_text)
+    print("\n=== Local ===")
+    print(processor.tokenizer.decode(local_ids[0], skip_special_tokens=True))
+    print("\n=== HF ===")
+    print(processor.tokenizer.decode(hf_ids[0], skip_special_tokens=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a minimal `models/smolVLM/` package with SigLIP vision encoder, pixel-shuffle projector, and SmolLM2-based language head
- add configuration helpers and Hugging Face weight loader bridging the published SmolVLM checkpoints into the local layout
- provide parity and smoke-test scripts under `test/smolVLM/` that mirror the existing SmolLM tools

## Testing
- python test/smolVLM/compare_hf_vs_local.py --steps 1 --dtype float32 --device cpu *(fails: logits diverge by ~20; further alignment needed)*
- python test/smolVLM/generate_smoke.py --max-new-tokens 1 --dtype float32 --device cpu *(completes, but local generation still differs from HF reference)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f6a83830832b8f521d46c79d798e