### PR TITLE
Modularise SmolVLM language stack

### DIFF
--- a/models/smolVLM/__init__.py
+++ b/models/smolVLM/__init__.py
@@ -1,0 +1,22 @@
+"""Minimal SmolVLM building blocks exposed as a small Python package."""
+from .attention import SmolVLMSelfAttention
+from .block import SmolVLMLanguageBlock
+from .config import SmolVLMConfig, SmolVLMVisionConfig, SmolVLMLanguageConfig
+from .language import SmolVLMLanguageModel
+from .mlp import SmolVLMFeedForward
+from .model import SmolVLM
+from .norms import SimpleRMSNorm
+from .rotary import RotaryPositionalEmbedding
+
+__all__ = [
+    "SmolVLMConfig",
+    "SmolVLMVisionConfig",
+    "SmolVLMLanguageConfig",
+    "SmolVLMLanguageModel",
+    "SmolVLM",
+    "SmolVLMSelfAttention",
+    "SmolVLMLanguageBlock",
+    "SmolVLMFeedForward",
+    "SimpleRMSNorm",
+    "RotaryPositionalEmbedding",
+]

--- a/models/smolVLM/attention.py
+++ b/models/smolVLM/attention.py
@@ -1,0 +1,80 @@
+"""Attention module used by the SmolVLM language transformer."""
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .config import SmolVLMLanguageConfig
+from .rotary import RotaryPositionalEmbedding
+
+
+class SmolVLMSelfAttention(nn.Module):
+    """Grouped-query causal self-attention."""
+
+    def __init__(self, cfg: SmolVLMLanguageConfig) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.num_query_heads = cfg.num_attention_heads
+        self.num_kv_heads = cfg.num_key_value_heads
+        self.head_dim = cfg.head_dim
+
+        projection_dim = self.num_query_heads * self.head_dim
+        kv_dim = self.num_kv_heads * self.head_dim
+
+        # Separate linear layers keep the logic easy to follow.
+        self.q_proj = nn.Linear(cfg.hidden_size, projection_dim, bias=False)
+        self.k_proj = nn.Linear(cfg.hidden_size, kv_dim, bias=False)
+        self.v_proj = nn.Linear(cfg.hidden_size, kv_dim, bias=False)
+        self.o_proj = nn.Linear(projection_dim, cfg.hidden_size, bias=False)
+
+        self.attention_dropout = nn.Dropout(cfg.dropout)
+        self.residual_dropout = nn.Dropout(cfg.dropout)
+        self.rotary = RotaryPositionalEmbedding(cfg.head_dim, cfg.max_position_embeddings, cfg.rope_theta)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        attention_mask: Optional[torch.Tensor],
+        position_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        batch_size, seq_len, _ = hidden_states.shape
+
+        # Project the input to query/key/value tensors and reshape to explicitly
+        # expose the head dimension.  Shape after ``view``: [batch, seq, heads, dim].
+        query = self.q_proj(hidden_states).view(batch_size, seq_len, self.num_query_heads, self.head_dim)
+        key = self.k_proj(hidden_states).view(batch_size, seq_len, self.num_kv_heads, self.head_dim)
+        value = self.v_proj(hidden_states).view(batch_size, seq_len, self.num_kv_heads, self.head_dim)
+
+        # Apply rotary embeddings before the dot-product is taken.
+        query, key = self.rotary(query, key, positions=position_ids)
+
+        # ``repeat_interleave`` duplicates key/value heads so every query head has
+        # a matching partner.  This is what turns grouped-query attention into an
+        # efficient implementation detail instead of a behavioural change.
+        if self.num_kv_heads != self.num_query_heads:
+            replication = self.num_query_heads // self.num_kv_heads
+            key = key.repeat_interleave(replication, dim=2)
+            value = value.repeat_interleave(replication, dim=2)
+
+        # ``scaled_dot_product_attention`` expects [batch, heads, seq, dim].
+        query = query.permute(0, 2, 1, 3)
+        key = key.permute(0, 2, 1, 3)
+        value = value.permute(0, 2, 1, 3)
+
+        attn_output = F.scaled_dot_product_attention(
+            query,
+            key,
+            value,
+            attn_mask=attention_mask,
+            dropout_p=self.attention_dropout.p if self.training else 0.0,
+            is_causal=True,
+        )
+
+        # Collapse the heads back into the hidden dimension.
+        attn_output = attn_output.transpose(1, 2).contiguous().view(batch_size, seq_len, -1)
+        attn_output = self.o_proj(attn_output)
+        return self.residual_dropout(attn_output)

--- a/models/smolVLM/block.py
+++ b/models/smolVLM/block.py
@@ -1,0 +1,40 @@
+"""Transformer block wiring the SmolVLM attention + feed-forward."""
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+from .attention import SmolVLMSelfAttention
+from .config import SmolVLMLanguageConfig
+from .mlp import SmolVLMFeedForward
+from .norms import SimpleRMSNorm
+
+
+class SmolVLMLanguageBlock(nn.Module):
+    """Pre-normalised transformer block (attention + feed-forward)."""
+
+    def __init__(self, cfg: SmolVLMLanguageConfig) -> None:
+        super().__init__()
+        self.ln_attn = SimpleRMSNorm(cfg.hidden_size, eps=cfg.rms_norm_eps)
+        self.attn = SmolVLMSelfAttention(cfg)
+        self.ln_mlp = SimpleRMSNorm(cfg.hidden_size, eps=cfg.rms_norm_eps)
+        self.mlp = SmolVLMFeedForward(cfg)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        attention_mask: Optional[torch.Tensor],
+        position_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        # Attention branch.
+        attn_input = self.ln_attn(hidden_states)
+        attn_output = self.attn(attn_input, attention_mask=attention_mask, position_ids=position_ids)
+        hidden_states = hidden_states + attn_output
+
+        # Feed-forward branch.
+        mlp_input = self.ln_mlp(hidden_states)
+        mlp_output = self.mlp(mlp_input)
+        return hidden_states + mlp_output

--- a/models/smolVLM/config.py
+++ b/models/smolVLM/config.py
@@ -1,0 +1,146 @@
+"""Configuration dataclasses that describe the minimal SmolVLM layout."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - only needed for static type checkers
+    from transformers import Idefics3Config
+
+
+@dataclass
+class SmolVLMVisionConfig:
+    """Hyper-parameters steering the SigLIP-style vision transformer.
+
+    The vision encoder is a straightforward ViT: images are split into patches,
+    each patch is linearly projected, and a stack of transformer blocks operates
+    over the resulting sequence.  The fields below provide just enough
+    information to rebuild that architecture from scratch in ``vision.py``.
+    """
+
+    image_size: int
+    patch_size: int
+    num_channels: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    layer_norm_eps: float = 1e-6
+    attention_dropout: float = 0.0
+    hidden_act: str = "gelu_pytorch_tanh"
+
+    @property
+    def num_patches_per_side(self) -> int:
+        """Number of patches that fit along the height/width of the image."""
+
+        return self.image_size // self.patch_size
+
+    @property
+    def num_patches(self) -> int:
+        """Total patch count in a square grid (used to size positional tables)."""
+
+        side = self.num_patches_per_side
+        return side * side
+
+
+@dataclass
+class SmolVLMLanguageConfig:
+    """Parameters that define the decoder-only language stack.
+
+    SmolVLM follows a LLaMA-like design: grouped-query attention with rotary
+    embeddings and SwiGLU feed-forward networks.  We keep the dataclass explicit
+    so each hyper-parameter is visible at call sites, mirroring the educational
+    tone of the rest of the project.
+    """
+
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    max_position_embeddings: int
+    rope_theta: float
+    rms_norm_eps: float
+    dropout: float = 0.0
+    tie_embeddings: bool = False
+    pad_token_id: int = 0
+
+    @property
+    def head_dim(self) -> int:
+        """Dimension of a single attention head (convenience helper)."""
+
+        if self.hidden_size % self.num_attention_heads != 0:
+            raise ValueError("hidden_size must be divisible by num_attention_heads")
+        return self.hidden_size // self.num_attention_heads
+
+
+@dataclass
+class SmolVLMConfig:
+    """Bundle vision + language settings together with VL glue metadata."""
+
+    vision: SmolVLMVisionConfig
+    language: SmolVLMLanguageConfig
+    image_token_id: int
+    pad_token_id: int
+    scale_factor: int = 1
+    mm_hidden_size: Optional[int] = None
+
+    @classmethod
+    def from_hf_config(cls, hf_cfg: "Idefics3Config") -> "SmolVLMConfig":
+        """Translate a Hugging Face ``Idefics3Config`` into light-weight dataclasses."""
+
+        vision_cfg = hf_cfg.vision_config
+        text_cfg = hf_cfg.text_config
+
+        # --- vision -----------------------------------------------------------------
+        # Hugging Face stores the maximum processed size separately from the original
+        # training image size.  Prefer the explicit ``image_size`` attribute when
+        # present, otherwise fall back to ``size["longest_edge"]``.
+        vision = SmolVLMVisionConfig(
+            image_size=int(getattr(vision_cfg, "image_size", 0) or vision_cfg.size["longest_edge"]),
+            patch_size=int(vision_cfg.patch_size),
+            num_channels=int(vision_cfg.num_channels),
+            hidden_size=int(vision_cfg.hidden_size),
+            intermediate_size=int(vision_cfg.intermediate_size),
+            num_hidden_layers=int(vision_cfg.num_hidden_layers),
+            num_attention_heads=int(vision_cfg.num_attention_heads),
+            layer_norm_eps=float(vision_cfg.layer_norm_eps),
+            attention_dropout=float(getattr(vision_cfg, "attention_dropout", 0.0)),
+            hidden_act=str(getattr(vision_cfg, "hidden_act", "gelu_pytorch_tanh")),
+        )
+
+        # --- language ---------------------------------------------------------------
+        language = SmolVLMLanguageConfig(
+            vocab_size=int(text_cfg.vocab_size),
+            hidden_size=int(text_cfg.hidden_size),
+            intermediate_size=int(text_cfg.intermediate_size),
+            num_hidden_layers=int(text_cfg.num_hidden_layers),
+            num_attention_heads=int(text_cfg.num_attention_heads),
+            num_key_value_heads=int(getattr(text_cfg, "num_key_value_heads", text_cfg.num_attention_heads)),
+            max_position_embeddings=int(text_cfg.max_position_embeddings),
+            rope_theta=float(getattr(text_cfg, "rope_theta", 100000.0)),
+            rms_norm_eps=float(getattr(text_cfg, "rms_norm_eps", 1e-5)),
+            dropout=float(getattr(text_cfg, "attention_dropout", 0.0)),
+            tie_embeddings=bool(
+                getattr(hf_cfg, "tie_word_embeddings", getattr(text_cfg, "tie_word_embeddings", False))
+            ),
+            pad_token_id=int(getattr(text_cfg, "pad_token_id", getattr(hf_cfg, "pad_token_id", 0) or 0)),
+        )
+
+        # --- multimodal glue --------------------------------------------------------
+        scale_factor = int(getattr(hf_cfg, "scale_factor", getattr(text_cfg, "pixel_shuffle_factor", 1)))
+        mm_hidden = getattr(hf_cfg, "mm_hidden_size", None)
+        if mm_hidden is not None:
+            mm_hidden = int(mm_hidden)
+
+        pad_id = int(getattr(hf_cfg, "pad_token_id", language.pad_token_id))
+        return cls(
+            vision=vision,
+            language=language,
+            image_token_id=int(getattr(hf_cfg, "image_token_id", 0)),
+            pad_token_id=pad_id,
+            scale_factor=max(scale_factor, 1),
+            mm_hidden_size=mm_hidden,
+        )
+

--- a/models/smolVLM/language.py
+++ b/models/smolVLM/language.py
@@ -1,0 +1,110 @@
+"""Top-level decoder-only language model stitched from modular building blocks."""
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from .block import SmolVLMLanguageBlock
+from .config import SmolVLMLanguageConfig
+from .norms import SimpleRMSNorm
+
+
+class SmolVLMLanguageModel(nn.Module):
+    """Decoder-only transformer rebuilt with verbose, reader-friendly comments."""
+
+    def __init__(self, cfg: SmolVLMLanguageConfig) -> None:
+        super().__init__()
+        self.cfg = cfg
+
+        # Token embedding table translating vocabulary ids into dense vectors.
+        self.tok_emb = nn.Embedding(cfg.vocab_size, cfg.hidden_size)
+        self.dropout = nn.Dropout(cfg.dropout)
+        self.blocks = nn.ModuleList([SmolVLMLanguageBlock(cfg) for _ in range(cfg.num_hidden_layers)])
+        self.norm_out = SimpleRMSNorm(cfg.hidden_size, eps=cfg.rms_norm_eps)
+        self.lm_head = nn.Linear(cfg.hidden_size, cfg.vocab_size, bias=False)
+
+        if cfg.tie_embeddings:
+            # Sharing parameters keeps the number of learnable tensors small and
+            # mirrors what Hugging Face does for LLaMA checkpoints.
+            self.lm_head.weight = self.tok_emb.weight
+
+        self.apply(self._init_weights)
+
+    # ------------------------------------------------------------------ helpers
+    def _init_weights(self, module: nn.Module) -> None:
+        if isinstance(module, nn.Linear):
+            nn.init.normal_(module.weight, mean=0.0, std=0.02)
+        elif isinstance(module, nn.Embedding):
+            nn.init.normal_(module.weight, mean=0.0, std=0.02)
+
+    def _prepare_attention_inputs(
+        self,
+        attention_mask: Optional[torch.Tensor],
+        position_ids: Optional[torch.Tensor],
+        *,
+        batch_size: int,
+        seq_len: int,
+        device: torch.device,
+    ) -> Tuple[Optional[torch.Tensor], torch.Tensor]:
+        """Build attention masks + rotary position ids from user input.
+
+        Hugging Face follows the convention where ``1`` marks valid tokens and
+        ``0`` marks padding.  We flip that into a boolean mask that PyTorch's
+        attention kernel expects (``True`` = ignore).  For positional encodings we
+        either reuse the provided tensor or create contiguous positions that skip
+        over padding tokens.
+        """
+
+        if attention_mask is not None:
+            is_padding = ~attention_mask.bool()
+            attn_mask = is_padding[:, None, None, :]
+            if position_ids is None:
+                # ``cumsum`` assigns increasing numbers to non-padding tokens.
+                position_ids = (attention_mask.long().cumsum(-1) - 1).clamp_min(0)
+        else:
+            attn_mask = None
+            if position_ids is None:
+                position_ids = torch.arange(seq_len, device=device).unsqueeze(0).expand(batch_size, seq_len)
+        return attn_mask, position_ids
+
+    # ------------------------------------------------------------------ forward
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Convenience wrapper that starts from integer token ids."""
+
+        embeddings = self.tok_emb(input_ids)
+        return self.forward_from_embeddings(
+            embeddings,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+        )
+
+    def forward_from_embeddings(
+        self,
+        embeddings: torch.Tensor,
+        *,
+        attention_mask: Optional[torch.Tensor],
+        position_ids: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Run the transformer using pre-computed token embeddings."""
+
+        batch_size, seq_len, _ = embeddings.shape
+        attn_mask, position_ids = self._prepare_attention_inputs(
+            attention_mask,
+            position_ids,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            device=embeddings.device,
+        )
+
+        hidden_states = self.dropout(embeddings)
+        for block in self.blocks:
+            hidden_states = block(hidden_states, attention_mask=attn_mask, position_ids=position_ids)
+        hidden_states = self.norm_out(hidden_states)
+        return self.lm_head(hidden_states)

--- a/models/smolVLM/mlp.py
+++ b/models/smolVLM/mlp.py
@@ -1,0 +1,26 @@
+"""Feed-forward network used inside the SmolVLM language block."""
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .config import SmolVLMLanguageConfig
+
+
+class SmolVLMFeedForward(nn.Module):
+    """SwiGLU feed-forward network used inside each language block."""
+
+    def __init__(self, cfg: SmolVLMLanguageConfig) -> None:
+        super().__init__()
+        hidden = cfg.intermediate_size
+        self.in_proj = nn.Linear(cfg.hidden_size, hidden * 2, bias=False)
+        self.out_proj = nn.Linear(hidden, cfg.hidden_size, bias=False)
+        self.dropout = nn.Dropout(cfg.dropout)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        # ``chunk`` splits the projection into gate + candidate tensors.
+        gate_values, candidate_values = self.in_proj(hidden_states).chunk(2, dim=-1)
+        activated = F.silu(gate_values) * candidate_values
+        activated = self.out_proj(activated)
+        return self.dropout(activated)

--- a/models/smolVLM/model.py
+++ b/models/smolVLM/model.py
@@ -1,0 +1,362 @@
+"""Combined vision-language model closely tracking the SmolVLM layout."""
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .config import SmolVLMConfig
+from .language import SmolVLMLanguageModel
+from .projector import SmolVLMMultiModalProjector
+from .vision import SmolVLMVisionEncoder
+
+
+class SmolVLM(nn.Module):
+    """Minimal reproduction of the SmolVLM architecture."""
+
+    def __init__(self, cfg: SmolVLMConfig) -> None:
+        super().__init__()
+        self.cfg = cfg
+
+        # --- vision + projector --------------------------------------------------
+        # The SigLIP encoder turns raw pixels into a sequence of patch embeddings.
+        self.vision_encoder = SmolVLMVisionEncoder(cfg.vision)
+        vision_dim = cfg.vision.hidden_size * (cfg.scale_factor ** 2)
+        self.mm_projector = SmolVLMMultiModalProjector(
+            vision_dim=vision_dim,
+            text_dim=cfg.language.hidden_size,
+            scale_factor=cfg.scale_factor,
+            hidden_dim=cfg.mm_hidden_size,
+        )
+        # The language model is implemented locally in ``language.py`` rather
+        # than reusing SmolLM2 to keep the code path easy to follow.
+        self.language_model = SmolVLMLanguageModel(cfg.language)
+
+        # Initialise the vision + projector layers with the same Gaussian scheme
+        # used for the language model.  This mirrors the behaviour of the Hugging
+        # Face checkpoints and makes weight-loading round-trips predictable.
+        self.vision_encoder.apply(self._init_weights)
+        self.mm_projector.apply(self._init_weights)
+
+    @staticmethod
+    def _init_weights(module: nn.Module) -> None:
+        if isinstance(module, (nn.Linear, nn.Conv2d)):
+            nn.init.normal_(module.weight, mean=0.0, std=0.02)
+            if module.bias is not None:
+                nn.init.zeros_(module.bias)
+
+    # --------------------------------------------------------------------- utils
+    def num_parameters(self, trainable_only: bool = False) -> int:
+        params = self.parameters() if not trainable_only else (p for p in self.parameters() if p.requires_grad)
+        return sum(p.numel() for p in params)
+
+    # ------------------------------------------------------------------- features
+    def get_image_features(
+        self,
+        pixel_values: torch.Tensor,
+        pixel_attention_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Encode a batch of images so they can be spliced into the text stream."""
+
+        batch_size, images_per_prompt, channels, height, width = pixel_values.shape
+        target_dtype = self.language_model.tok_emb.weight.dtype
+        device = pixel_values.device
+
+        # Merge the batch and image dimensions.  Processor pipelines sometimes
+        # pad the image slots with zeros; we drop those "blank" placeholders to
+        # keep the downstream loops simple.
+        image_grid = pixel_values.to(dtype=target_dtype)
+        image_grid = image_grid.view(batch_size * images_per_prompt, channels, height, width)
+        values_per_image = channels * height * width
+        is_blank_image = (image_grid == 0.0).view(image_grid.size(0), values_per_image).all(dim=1)
+        real_image_mask = ~is_blank_image
+        image_grid = image_grid[real_image_mask].contiguous()
+
+        # Align the optional pixel-level attention mask with the filtered images.
+        if pixel_attention_mask is None:
+            pixel_attention_mask = torch.ones(
+                (image_grid.size(0), height, width), dtype=torch.bool, device=device
+            )
+        else:
+            pixel_attention_mask = pixel_attention_mask.view(
+                batch_size * images_per_prompt, *pixel_attention_mask.shape[2:]
+            )
+            pixel_attention_mask = pixel_attention_mask[real_image_mask].contiguous()
+
+        if image_grid.numel() == 0:
+            return torch.zeros((0, 0, self.cfg.language.hidden_size), device=device, dtype=target_dtype)
+
+        # Convert pixel-level masks to patch-level masks.  ``unfold`` slides a
+        # non-overlapping window so we can flag patches that contain any valid
+        # pixels.  SigLIP treats masked patches as padding, so we only need a
+        # boolean indicator per patch.
+        patch_size = self.cfg.vision.patch_size
+        patches = pixel_attention_mask.unfold(1, patch_size, patch_size).unfold(2, patch_size, patch_size)
+        patch_attention_mask = patches.sum(dim=(-1, -2)) > 0
+
+        vision_hidden = self.vision_encoder(image_grid, patch_attention_mask=patch_attention_mask)
+        projected = self.mm_projector(vision_hidden)
+        return projected.to(dtype=target_dtype)
+
+    def _merge_image_embeddings(
+        self,
+        input_ids: torch.Tensor,
+        inputs_embeds: torch.Tensor,
+        image_hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        if image_hidden_states.numel() == 0:
+            return inputs_embeds
+
+        image_hidden_states = image_hidden_states.to(device=inputs_embeds.device, dtype=inputs_embeds.dtype)
+
+        # ``<image>`` placeholders are expanded into full sequences of embeddings.
+        image_token_mask = (input_ids == self.cfg.image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
+        expected_values = int(image_token_mask.sum().item())
+        if expected_values != image_hidden_states.numel():
+            raise ValueError("Mismatch between number of <image> tokens and image hidden states")
+
+        merged = inputs_embeds.masked_scatter(image_token_mask, image_hidden_states.reshape(-1))
+        return merged.view_as(inputs_embeds)
+
+    def _run_language_model(
+        self,
+        inputs_embeds: torch.Tensor,
+        *,
+        attention_mask: Optional[torch.Tensor],
+        position_ids: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        # Delegate to the hand-written language model so the bridging logic lives
+        # in one place.  ``forward_from_embeddings`` simply wraps the standard
+        # ``forward`` method but skips the embedding lookup because we already
+        # replaced ``<image>`` tokens with vision features.
+        return self.language_model.forward_from_embeddings(
+            inputs_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+        )
+
+    # -------------------------------------------------------------------- forward
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        *,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        pixel_values: Optional[torch.Tensor] = None,
+        pixel_attention_mask: Optional[torch.Tensor] = None,
+        image_hidden_states: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if image_hidden_states is not None and pixel_values is not None:
+            raise ValueError("Provide either pixel_values or precomputed image_hidden_states, not both")
+        if image_hidden_states is None and pixel_values is not None:
+            image_hidden_states = self.get_image_features(pixel_values, pixel_attention_mask)
+
+        inputs_embeds = self.language_model.tok_emb(input_ids)
+        if image_hidden_states is not None:
+            inputs_embeds = self._merge_image_embeddings(input_ids, inputs_embeds, image_hidden_states)
+        return self._run_language_model(inputs_embeds, attention_mask=attention_mask, position_ids=position_ids)
+
+    # ------------------------------------------------------------------- sampling
+    @torch.no_grad()
+    def generate(
+        self,
+        input_ids: torch.Tensor,
+        *,
+        pixel_values: Optional[torch.Tensor] = None,
+        pixel_attention_mask: Optional[torch.Tensor] = None,
+        max_new_tokens: int = 50,
+        temperature: float = 1.0,
+        top_k: Optional[int] = None,
+    ) -> torch.Tensor:
+        self.eval()
+        image_hidden_states = None
+        if pixel_values is not None:
+            image_hidden_states = self.get_image_features(pixel_values, pixel_attention_mask)
+        generated = input_ids
+        for _ in range(max_new_tokens):
+            logits = self(
+                generated,
+                image_hidden_states=image_hidden_states,
+            )[:, -1, :]
+            logits = logits / max(temperature, 1e-6)
+            if top_k is not None:
+                values, _ = torch.topk(logits, min(top_k, logits.size(-1)))
+                thresh = values[:, [-1]]
+                logits = logits.masked_fill(logits < thresh, -float("inf"))
+            probs = F.softmax(logits, dim=-1)
+            next_id = torch.multinomial(probs, num_samples=1)
+            generated = torch.cat([generated, next_id], dim=1)
+        return generated
+
+    # --------------------------------------------------------------------- loading
+    def load_hf_state_dict(
+        self,
+        hf_state: Dict[str, torch.Tensor],
+        *,
+        strict: bool = False,
+        verbose: bool = True,
+        dtype: Optional[torch.dtype] = None,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        ref_param = next(self.parameters(), None)
+        if dtype is None:
+            dtype = ref_param.dtype if ref_param is not None else torch.float32
+        if device is None:
+            device = ref_param.device if ref_param is not None else torch.device("cpu")
+
+        used_keys = set()
+        missing = []
+        mismatched = []
+
+        params = dict(self.named_parameters())
+        buffers = dict(self.named_buffers())
+
+        def fetch(*names: str, mark_only: bool = False) -> Optional[torch.Tensor]:
+            for name in names:
+                if name in hf_state:
+                    used_keys.add(name)
+                    if mark_only:
+                        return None
+                    return hf_state[name].to(device=device, dtype=dtype)
+            return None
+
+        def assign(target_name: str, value: Optional[torch.Tensor]) -> None:
+            if value is None:
+                missing.append(target_name)
+                return
+            target = params.get(target_name)
+            if target is None:
+                target = buffers.get(target_name)
+            if target is None:
+                missing.append(target_name)
+                return
+            if tuple(target.shape) != tuple(value.shape):
+                mismatched.append((target_name, tuple(target.shape), tuple(value.shape)))
+                return
+            target.data.copy_(value)
+
+        # --- resolve prefixes -------------------------------------------------
+        state_keys = list(hf_state.keys())
+
+        def prefix_for(candidates):
+            for prefix in candidates:
+                if any(key.startswith(prefix) for key in state_keys):
+                    return prefix
+            return None
+
+        vision_prefix = prefix_for([
+            "model.vision_model",
+            "vision_model",
+        ])
+        projector_prefix = prefix_for([
+            "model.connector.modality_projection",
+            "connector.modality_projection",
+            "model.multi_modal_projector",
+            "multi_modal_projector",
+        ])
+        text_prefix = prefix_for([
+            "model.language_model.model",
+            "model.text_model",
+            "language_model.model",
+            "text_model",
+        ])
+
+        # --- vision embeddings ------------------------------------------------
+        if vision_prefix:
+            assign("vision_encoder.patch_embed.weight", fetch(f"{vision_prefix}.embeddings.patch_embedding.weight"))
+            assign("vision_encoder.patch_embed.bias", fetch(f"{vision_prefix}.embeddings.patch_embedding.bias"))
+            assign("vision_encoder.pos_embed", fetch(f"{vision_prefix}.embeddings.position_embedding.weight"))
+            cls_token = fetch(f"{vision_prefix}.embeddings.class_embedding")
+            if cls_token is not None:
+                assign("vision_encoder.cls_token", cls_token)
+            assign("vision_encoder.ln_post.weight", fetch(f"{vision_prefix}.post_layernorm.weight"))
+            assign("vision_encoder.ln_post.bias", fetch(f"{vision_prefix}.post_layernorm.bias"))
+
+            for idx in range(len(self.vision_encoder.blocks)):
+                block = f"vision_encoder.blocks.{idx}"
+                assign(f"{block}.ln1.weight", fetch(f"{vision_prefix}.encoder.layers.{idx}.layer_norm1.weight"))
+                assign(f"{block}.ln1.bias", fetch(f"{vision_prefix}.encoder.layers.{idx}.layer_norm1.bias"))
+                assign(f"{block}.ln2.weight", fetch(f"{vision_prefix}.encoder.layers.{idx}.layer_norm2.weight"))
+                assign(f"{block}.ln2.bias", fetch(f"{vision_prefix}.encoder.layers.{idx}.layer_norm2.bias"))
+
+                assign(f"{block}.attn.q_proj.weight", fetch(f"{vision_prefix}.encoder.layers.{idx}.self_attn.q_proj.weight"))
+                assign(f"{block}.attn.q_proj.bias", fetch(f"{vision_prefix}.encoder.layers.{idx}.self_attn.q_proj.bias"))
+                assign(f"{block}.attn.k_proj.weight", fetch(f"{vision_prefix}.encoder.layers.{idx}.self_attn.k_proj.weight"))
+                assign(f"{block}.attn.k_proj.bias", fetch(f"{vision_prefix}.encoder.layers.{idx}.self_attn.k_proj.bias"))
+                assign(f"{block}.attn.v_proj.weight", fetch(f"{vision_prefix}.encoder.layers.{idx}.self_attn.v_proj.weight"))
+                assign(f"{block}.attn.v_proj.bias", fetch(f"{vision_prefix}.encoder.layers.{idx}.self_attn.v_proj.bias"))
+                assign(f"{block}.attn.o_proj.weight", fetch(f"{vision_prefix}.encoder.layers.{idx}.self_attn.out_proj.weight"))
+                assign(f"{block}.attn.o_proj.bias", fetch(f"{vision_prefix}.encoder.layers.{idx}.self_attn.out_proj.bias"))
+
+                assign(f"{block}.mlp.fc1.weight", fetch(f"{vision_prefix}.encoder.layers.{idx}.mlp.fc1.weight"))
+                assign(f"{block}.mlp.fc1.bias", fetch(f"{vision_prefix}.encoder.layers.{idx}.mlp.fc1.bias"))
+                assign(f"{block}.mlp.fc2.weight", fetch(f"{vision_prefix}.encoder.layers.{idx}.mlp.fc2.weight"))
+                assign(f"{block}.mlp.fc2.bias", fetch(f"{vision_prefix}.encoder.layers.{idx}.mlp.fc2.bias"))
+
+        # --- projector --------------------------------------------------------
+        if projector_prefix:
+            if hasattr(self.mm_projector, "proj"):
+                assign("mm_projector.proj.weight", fetch(f"{projector_prefix}.proj.weight", f"{projector_prefix}.linear_2.weight"))
+                bias = fetch(f"{projector_prefix}.proj.bias", f"{projector_prefix}.linear_2.bias")
+                if bias is not None:
+                    assign("mm_projector.proj.bias", bias)
+            else:
+                assign("mm_projector.linear1.weight", fetch(f"{projector_prefix}.linear_1.weight"))
+                assign("mm_projector.linear1.bias", fetch(f"{projector_prefix}.linear_1.bias"))
+                assign("mm_projector.linear2.weight", fetch(f"{projector_prefix}.linear_2.weight"))
+                assign("mm_projector.linear2.bias", fetch(f"{projector_prefix}.linear_2.bias"))
+
+        # --- language ---------------------------------------------------------
+        if text_prefix:
+            assign("language_model.tok_emb.weight", fetch(f"{text_prefix}.embed_tokens.weight"))
+            assign("language_model.norm_out.weight", fetch(f"{text_prefix}.norm.weight", f"{text_prefix}.model.norm.weight"))
+
+            for idx in range(len(self.language_model.blocks)):
+                block = f"language_model.blocks.{idx}"
+                assign(f"{block}.ln_attn.weight", fetch(f"{text_prefix}.layers.{idx}.input_layernorm.weight"))
+                assign(f"{block}.ln_mlp.weight", fetch(f"{text_prefix}.layers.{idx}.post_attention_layernorm.weight"))
+
+                assign(f"{block}.attn.q_proj.weight", fetch(f"{text_prefix}.layers.{idx}.self_attn.q_proj.weight"))
+                assign(f"{block}.attn.k_proj.weight", fetch(f"{text_prefix}.layers.{idx}.self_attn.k_proj.weight"))
+                assign(f"{block}.attn.v_proj.weight", fetch(f"{text_prefix}.layers.{idx}.self_attn.v_proj.weight"))
+                assign(f"{block}.attn.o_proj.weight", fetch(f"{text_prefix}.layers.{idx}.self_attn.o_proj.weight"))
+
+                gate = fetch(f"{text_prefix}.layers.{idx}.mlp.gate_proj.weight", f"{text_prefix}.layers.{idx}.mlp.w1.weight")
+                up = fetch(f"{text_prefix}.layers.{idx}.mlp.up_proj.weight", f"{text_prefix}.layers.{idx}.mlp.w3.weight")
+                combined = fetch(f"{text_prefix}.layers.{idx}.mlp.fc1.weight")
+                mlp_in = self._stack_gate_up(gate, up, combined)
+                assign(f"{block}.mlp.in_proj.weight", mlp_in)
+                assign(f"{block}.mlp.out_proj.weight", fetch(f"{text_prefix}.layers.{idx}.mlp.down_proj.weight", f"{text_prefix}.layers.{idx}.mlp.w2.weight"))
+
+            assign("language_model.lm_head.weight", fetch("lm_head.weight", "model.lm_head.weight"))
+
+        unused = [key for key in hf_state if key not in used_keys]
+        if verbose:
+            print(f"[load_hf] copied tensors: {len(used_keys)}")
+            if missing:
+                print(f"[load_hf] missing target params: {len(missing)} (up to 10) -> {missing[:10]}")
+            if mismatched:
+                print(f"[load_hf] shape mismatches: {len(mismatched)} (first) -> {mismatched[0]}")
+            if unused:
+                print(f"[load_hf] unused source tensors: {len(unused)} (up to 10) -> {unused[:10]}")
+
+        if strict and (missing or mismatched):
+            raise RuntimeError("[load_hf strict] missing or mismatched parameters")
+
+    @staticmethod
+    def _stack_gate_up(
+        gate: Optional[torch.Tensor],
+        up: Optional[torch.Tensor],
+        combined: Optional[torch.Tensor],
+    ) -> Optional[torch.Tensor]:
+        if gate is not None and up is not None:
+            return torch.cat([gate, up], dim=0)
+        return combined
+
+    # ---------------------------------------------------------------- factory
+    @staticmethod
+    def from_config_dict(cfg_dict: Dict) -> "SmolVLM":
+        return SmolVLM(SmolVLMConfig(**cfg_dict))
+

--- a/models/smolVLM/norms.py
+++ b/models/smolVLM/norms.py
@@ -1,0 +1,30 @@
+"""Normalisation layers purpose-built for the SmolVLM language stack."""
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class SimpleRMSNorm(nn.Module):
+    """Root-mean-square normalisation with a single learnable scale.
+
+    ``LayerNorm`` subtracts the mean and divides by the standard deviation.
+    LLaMA-style models instead scale each feature by the *root mean square* of
+    the activations.  This variant is marginally cheaper (no mean subtraction)
+    while keeping the same stabilising effect.  The implementation fits in a
+    handful of lines which makes it ideal for an educational code base.
+    """
+
+    def __init__(self, hidden_size: int, eps: float) -> None:
+        super().__init__()
+        self.eps = eps
+        # ``weight`` stretches or shrinks each feature after normalisation.
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        # ``inputs`` has shape [batch, seq_len, hidden_size].  We reduce over the
+        # last dimension to obtain the per-token variance.
+        variance = inputs.pow(2).mean(dim=-1, keepdim=True)
+        inv_rms = torch.rsqrt(variance + self.eps)
+        normalised = inputs * inv_rms
+        return normalised * self.weight

--- a/models/smolVLM/projector.py
+++ b/models/smolVLM/projector.py
@@ -1,0 +1,55 @@
+"""Utilities for mapping vision features into the language space."""
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class SmolVLMMultiModalProjector(nn.Module):
+    """Pixel-shuffle followed by a small MLP to match the text dimension."""
+
+    def __init__(self, *, vision_dim: int, text_dim: int, scale_factor: int, hidden_dim: Optional[int] = None) -> None:
+        super().__init__()
+        self.scale_factor = max(scale_factor, 1)
+        self.hidden_dim = hidden_dim
+        self.out_features = text_dim
+        if hidden_dim is None:
+            self.proj = nn.Linear(vision_dim, text_dim, bias=False)
+        else:
+            self.linear1 = nn.Linear(vision_dim, hidden_dim, bias=True)
+            self.linear2 = nn.Linear(hidden_dim, text_dim, bias=True)
+
+    def forward(self, image_hidden_states: torch.Tensor) -> torch.Tensor:
+        if image_hidden_states.numel() == 0:
+            return image_hidden_states.new_zeros((0, 0, self.out_features))
+
+        # ``pixel_shuffle`` rearranges the patch grid so each language token can
+        # attend to a slightly larger receptive field.  It is effectively the
+        # inverse of the pixel-unshuffle operation used in many vision models.
+        shuffled = self.pixel_shuffle(image_hidden_states, self.scale_factor)
+        if self.hidden_dim is None:
+            return self.proj(shuffled)
+        hidden = F.silu(self.linear1(shuffled))
+        return self.linear2(hidden)
+
+    @staticmethod
+    def pixel_shuffle(x: torch.Tensor, scale_factor: int) -> torch.Tensor:
+        if scale_factor <= 1:
+            return x
+        batch, seq_len, dim = x.shape
+        side = int(seq_len ** 0.5)
+        if side * side != seq_len:
+            raise ValueError(f"Sequence length {seq_len} is not a perfect square; cannot pixel-shuffle.")
+        if side % scale_factor != 0:
+            raise ValueError("Scale factor must divide the patch grid size")
+        new_side = side // scale_factor
+        x = x.view(batch, side, side, dim)
+        x = x.reshape(batch, new_side, scale_factor, new_side, scale_factor, dim)
+        # ``permute`` interleaves the high-resolution patches so each new token
+        # sees an expanded chunk of the original image.
+        x = x.permute(0, 1, 3, 2, 4, 5).contiguous()
+        x = x.reshape(batch, new_side * new_side, dim * (scale_factor ** 2))
+        return x

--- a/models/smolVLM/rotary.py
+++ b/models/smolVLM/rotary.py
@@ -1,0 +1,59 @@
+"""Rotary positional embedding helper for the SmolVLM language model."""
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+
+
+class RotaryPositionalEmbedding(nn.Module):
+    """Lightweight rotary embedding helper.
+
+    Rotary embeddings encode positions as rotations applied directly to the
+    query/key vectors.  The module below pre-computes inverse frequencies and
+    exposes a ``forward`` method that takes query/key tensors plus the integer
+    positions to rotate by.  Keeping this logic in one place avoids cluttering
+    the attention block with trigonometric boilerplate.
+    """
+
+    def __init__(self, head_dim: int, max_position_embeddings: int, base: float) -> None:
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_position_embeddings = max_position_embeddings
+        # Inverse frequencies follow the LLaMA recipe: even dimensions share the
+        # same frequency, odd dimensions reuse those values.  ``persistent=False``
+        # avoids storing the buffer inside checkpoints unnecessarily.
+        inv_freq = 1.0 / (base ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    @staticmethod
+    def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+        """Rotate the last dimension by swapping halves and flipping signs."""
+
+        half = x.shape[-1] // 2
+        first, second = x[..., :half], x[..., half:]
+        return torch.cat([-second, first], dim=-1)
+
+    def _compute_cos_sin(
+        self, positions: torch.Tensor, *, device: torch.device, dtype: torch.dtype
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # ``positions`` is integer valued with shape [batch, seq_len].  We cast to
+        # float so ``einsum`` can multiply by the inverse frequencies.  The result
+        # is a grid of angles; concatenating the tensor with itself aligns the
+        # values with the full head dimension (even + odd indices).
+        angles = torch.einsum("bt,d->btd", positions.to(torch.float32), self.inv_freq.to(device))
+        angles = torch.cat([angles, angles], dim=-1)
+        return angles.cos().to(dtype=dtype), angles.sin().to(dtype=dtype)
+
+    def forward(
+        self, query: torch.Tensor, key: torch.Tensor, positions: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        cos, sin = self._compute_cos_sin(positions, device=query.device, dtype=query.dtype)
+        # Broadcast ``cos``/``sin`` across the head dimension so each head shares
+        # the same rotation for a given token.
+        cos = cos.unsqueeze(2)
+        sin = sin.unsqueeze(2)
+        query = (query * cos) + (self._rotate_half(query) * sin)
+        key = (key * cos) + (self._rotate_half(key) * sin)
+        return query, key

--- a/models/smolVLM/vision.py
+++ b/models/smolVLM/vision.py
@@ -1,0 +1,165 @@
+"""Vision encoder mirroring the SmolVLM SigLIP backbone."""
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .config import SmolVLMVisionConfig
+
+
+def gelu_pytorch_tanh(x: torch.Tensor) -> torch.Tensor:
+    """Implementation of the tanh-approximated GELU used by SigLIP."""
+
+    return 0.5 * x * (1.0 + torch.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * x.pow(3))))
+
+
+def get_activation(name: str):
+    if name == "gelu" or name == "gelu_new":
+        return F.gelu
+    if name == "gelu_pytorch_tanh":
+        return gelu_pytorch_tanh
+    raise ValueError(f"Unsupported activation: {name}")
+
+
+class SmolVLMVisionAttention(nn.Module):
+    """Standard multi-head self-attention for the vision transformer."""
+
+    def __init__(self, cfg: SmolVLMVisionConfig) -> None:
+        super().__init__()
+        self.num_heads = cfg.num_attention_heads
+        self.head_dim = cfg.hidden_size // cfg.num_attention_heads
+        if self.head_dim * self.num_heads != cfg.hidden_size:
+            raise ValueError("hidden_size must be divisible by num_attention_heads")
+
+        self.q_proj = nn.Linear(cfg.hidden_size, cfg.hidden_size, bias=True)
+        self.k_proj = nn.Linear(cfg.hidden_size, cfg.hidden_size, bias=True)
+        self.v_proj = nn.Linear(cfg.hidden_size, cfg.hidden_size, bias=True)
+        self.o_proj = nn.Linear(cfg.hidden_size, cfg.hidden_size, bias=True)
+        self.dropout = nn.Dropout(cfg.attention_dropout)
+
+    def forward(self, hidden_states: torch.Tensor, attn_mask: Optional[torch.Tensor]) -> torch.Tensor:
+        batch, seq_len, hidden = hidden_states.shape
+        query = self.q_proj(hidden_states).view(batch, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+        key = self.k_proj(hidden_states).view(batch, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+        value = self.v_proj(hidden_states).view(batch, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+
+        mask = None
+        if attn_mask is not None:
+            neg_inf = torch.finfo(hidden_states.dtype).min
+            mask = (~attn_mask).to(dtype=hidden_states.dtype) * neg_inf
+            mask = mask.unsqueeze(1).unsqueeze(2)
+
+        attn_out = F.scaled_dot_product_attention(
+            query,
+            key,
+            value,
+            attn_mask=mask,
+            dropout_p=self.dropout.p if self.training else 0.0,
+            is_causal=False,
+        )
+        attn_out = attn_out.transpose(1, 2).contiguous().view(batch, seq_len, hidden)
+        return self.o_proj(attn_out)
+
+
+class SmolVLMVisionMLP(nn.Module):
+    """Feed-forward network used inside each vision transformer block."""
+
+    def __init__(self, cfg: SmolVLMVisionConfig) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(cfg.hidden_size, cfg.intermediate_size, bias=True)
+        self.fc2 = nn.Linear(cfg.intermediate_size, cfg.hidden_size, bias=True)
+        self.activation = get_activation(cfg.hidden_act)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.fc1(hidden_states)
+        hidden_states = self.activation(hidden_states)
+        return self.fc2(hidden_states)
+
+
+class SmolVLMVisionBlock(nn.Module):
+    """Pre-norm transformer block for the vision encoder."""
+
+    def __init__(self, cfg: SmolVLMVisionConfig) -> None:
+        super().__init__()
+        self.ln1 = nn.LayerNorm(cfg.hidden_size, eps=cfg.layer_norm_eps)
+        self.attn = SmolVLMVisionAttention(cfg)
+        self.ln2 = nn.LayerNorm(cfg.hidden_size, eps=cfg.layer_norm_eps)
+        self.mlp = SmolVLMVisionMLP(cfg)
+
+    def forward(self, hidden_states: torch.Tensor, attn_mask: Optional[torch.Tensor]) -> torch.Tensor:
+        attn_input = self.ln1(hidden_states)
+        hidden_states = hidden_states + self.attn(attn_input, attn_mask)
+        mlp_input = self.ln2(hidden_states)
+        return hidden_states + self.mlp(mlp_input)
+
+
+class SmolVLMVisionEncoder(nn.Module):
+    """Minimal SigLIP-style encoder used by SmolVLM."""
+
+    def __init__(self, cfg: SmolVLMVisionConfig) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.patch_embed = nn.Conv2d(cfg.num_channels, cfg.hidden_size, kernel_size=cfg.patch_size, stride=cfg.patch_size)
+        self.pos_embed = nn.Parameter(torch.zeros(cfg.num_patches, cfg.hidden_size))
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, cfg.hidden_size))  # kept for checkpoint compatibility
+        self.blocks = nn.ModuleList([SmolVLMVisionBlock(cfg) for _ in range(cfg.num_hidden_layers)])
+        self.ln_post = nn.LayerNorm(cfg.hidden_size, eps=cfg.layer_norm_eps)
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        patch_attention_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        batch = pixel_values.size(0)
+        device = pixel_values.device
+
+        if patch_attention_mask is None:
+            h = pixel_values.shape[2] // self.cfg.patch_size
+            w = pixel_values.shape[3] // self.cfg.patch_size
+            patch_attention_mask = torch.ones((batch, h, w), dtype=torch.bool, device=device)
+
+        hidden_states = self.patch_embed(pixel_values)
+        hidden_states = hidden_states.flatten(2).transpose(1, 2)
+
+        position_ids = self._build_position_ids(patch_attention_mask)
+        pos_embeds = F.embedding(position_ids, self.pos_embed)
+        hidden_states = hidden_states + pos_embeds
+
+        attn_mask = patch_attention_mask.view(batch, -1)
+        for block in self.blocks:
+            hidden_states = block(hidden_states, attn_mask)
+        return self.ln_post(hidden_states)
+
+    def _build_position_ids(self, patch_mask: torch.Tensor) -> torch.Tensor:
+        batch, h, w = patch_mask.shape
+        device = patch_mask.device
+        dtype = torch.float32
+        boundaries = torch.arange(
+            1 / self.cfg.num_patches_per_side,
+            1.0,
+            1 / self.cfg.num_patches_per_side,
+            device=device,
+            dtype=dtype,
+        )
+        position_ids = torch.zeros(batch, h * w, dtype=torch.long, device=device)
+        for batch_idx, mask in enumerate(patch_mask):
+            valid_flat = mask.view(-1)
+            if not torch.any(valid_flat):
+                continue
+            patches_h = int(mask[:, 0].sum().item())
+            patches_w = int(mask[0].sum().item())
+            if patches_h == 0 or patches_w == 0:
+                continue
+            frac_h = torch.arange(patches_h, device=device, dtype=dtype)
+            frac_w = torch.arange(patches_w, device=device, dtype=dtype)
+            frac_h = frac_h / max(patches_h, 1) * (1.0 - 1e-6)
+            frac_w = frac_w / max(patches_w, 1) * (1.0 - 1e-6)
+            bucket_h = torch.bucketize(frac_h, boundaries, right=True)
+            bucket_w = torch.bucketize(frac_w, boundaries, right=True)
+            pos = (bucket_h[:, None] * self.cfg.num_patches_per_side + bucket_w).reshape(-1)
+            position_ids[batch_idx, valid_flat] = pos[: int(valid_flat.sum().item())]
+        return position_ids

--- a/test/smolVLM/README.md
+++ b/test/smolVLM/README.md
@@ -1,0 +1,17 @@
+# SmolVLM Test Utilities
+
+These scripts mirror the SmolLM helpers but target the multimodal SmolVLM
+checkpoints.  They are intentionally lightweight, providing parity checks and
+quick sampling for the minimal implementation in `models/smolVLM/`.
+
+## Scripts
+
+- `compare_hf_vs_local.py` — downloads a Hugging Face SmolVLM checkpoint,
+  maps the weights into the local implementation, and runs a greedy
+  teacher-forced comparison for a text+image prompt.
+- `generate_smoke.py` — loads the weights and produces a short generated
+  response to a tiny text+image input.
+
+By default the scripts target `HuggingFaceTB/SmolVLM-256M-Base`, which is
+public.  Pass `--hf-model` to point at private or fine-tuned variants such as
+`HuggingFaceTB/SmolVLM2-256M-Video-Instruct` once you have access to them.

--- a/test/smolVLM/compare_hf_vs_local.py
+++ b/test/smolVLM/compare_hf_vs_local.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Parity check between the minimal SmolVLM and Hugging Face's reference model."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+from typing import Optional
+
+from PIL import Image
+import torch
+from transformers import AutoConfig, AutoModelForVision2Seq, AutoProcessor
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from models.smolVLM import SmolVLM, SmolVLMConfig  # noqa: E402
+
+DEFAULT_PROMPT = "Describe the image in one short sentence."
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--hf-model", default="HuggingFaceTB/SmolVLM-256M-Base")
+    p.add_argument("--revision", default=None)
+    p.add_argument("--device", default="cuda", choices=["cuda", "cpu"])
+    p.add_argument("--dtype", default="float32", choices=["float32", "float16", "bfloat16"])
+    p.add_argument("--steps", type=int, default=8, help="#teacher-forced decode steps to compare")
+    p.add_argument("--tol", type=float, default=2e-3, help="max allowed abs diff on logits")
+    p.add_argument("--prompt", default=None, help="override default prompt text")
+    p.add_argument("--image", default=None, help="path to an RGB image (defaults to a grey square)")
+    p.add_argument("--local-files-only", action="store_true")
+    p.add_argument("--trust-remote-code", action="store_true")
+    return p.parse_args()
+
+
+def build_prompt(processor: AutoProcessor, text: str) -> str:
+    bos = processor.tokenizer.bos_token or ""
+    image_token = getattr(processor, "image_token", "<image>")
+    terminator = processor.tokenizer.unk_token or ""
+    return f"{bos}User:{image_token}{text}{terminator}Assistant:"
+
+
+def load_image(path: Optional[str]) -> Image.Image:
+    if path is None:
+        return Image.new("RGB", (512, 512), color=(128, 128, 128))
+    return Image.open(path).convert("RGB")
+
+
+def main() -> None:
+    args = parse_args()
+    device = torch.device(args.device if (args.device == "cpu" or torch.cuda.is_available()) else "cpu")
+    dtype = {"float32": torch.float32, "float16": torch.float16, "bfloat16": torch.bfloat16}[args.dtype]
+
+    hf_cfg = AutoConfig.from_pretrained(
+        args.hf_model,
+        revision=args.revision,
+        local_files_only=args.local_files_only,
+        trust_remote_code=args.trust_remote_code,
+    )
+    processor = AutoProcessor.from_pretrained(
+        args.hf_model,
+        revision=args.revision,
+        local_files_only=args.local_files_only,
+        trust_remote_code=args.trust_remote_code,
+    )
+
+    prompt_text = args.prompt if args.prompt is not None else DEFAULT_PROMPT
+    prompt = build_prompt(processor, prompt_text)
+    image = load_image(args.image)
+    proc_inputs = processor(
+        text=[prompt],
+        images=[image],
+        padding=True,
+        return_tensors="pt",
+    )
+
+    input_ids = proc_inputs["input_ids"].to(device)
+    attention_mask = proc_inputs["attention_mask"].to(device)
+    pixel_values = proc_inputs["pixel_values"].to(device=device, dtype=dtype)
+    pixel_attention_mask = proc_inputs["pixel_attention_mask"].to(device)
+
+    smol_cfg = SmolVLMConfig.from_hf_config(hf_cfg)
+    local_model = SmolVLM(smol_cfg).to(device=device, dtype=dtype).eval()
+
+    hf_model = AutoModelForVision2Seq.from_pretrained(
+        args.hf_model,
+        revision=args.revision,
+        local_files_only=args.local_files_only,
+        trust_remote_code=args.trust_remote_code,
+        torch_dtype=dtype,
+        device_map={"": device.type},
+    ).eval()
+
+    local_model.load_hf_state_dict(hf_model.state_dict(), strict=False, verbose=True, dtype=dtype, device=device)
+
+    ids = input_ids.clone()
+    attn = attention_mask.clone()
+    for step in range(args.steps):
+        with torch.no_grad():
+            local_logits = local_model(
+                ids,
+                attention_mask=attn,
+                pixel_values=pixel_values,
+                pixel_attention_mask=pixel_attention_mask,
+            )[:, -1, :]
+            hf_out = hf_model(
+                input_ids=ids,
+                attention_mask=attn,
+                pixel_values=pixel_values,
+                pixel_attention_mask=pixel_attention_mask,
+            )
+            hf_logits = hf_out.logits[:, -1, :]
+        max_diff = (local_logits - hf_logits).abs().max().item()
+        print(f"[step {step}] max|Δlogits| = {max_diff:.6f}")
+        if max_diff > args.tol:
+            raise AssertionError(f"Logit mismatch at step {step}: {max_diff} > tol={args.tol}")
+        next_id = torch.argmax(hf_logits, dim=-1, keepdim=True)
+        ids = torch.cat([ids, next_id], dim=1)
+        attn = torch.cat([attn, attn.new_ones((attn.size(0), 1))], dim=1)
+
+    decoded = processor.tokenizer.decode(ids[0], skip_special_tokens=True)
+    print("\n=== PROMPT TEXT ===\n" + prompt_text)
+    print("\n=== LOCAL (teacher-forced path) ===\n" + decoded)
+    print("\nOK: logits matched within tolerance at each step.")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/smolVLM/generate_smoke.py
+++ b/test/smolVLM/generate_smoke.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Quick smoke-test generation for the minimal SmolVLM implementation."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+from typing import Optional
+
+from PIL import Image
+import torch
+from transformers import AutoConfig, AutoModelForVision2Seq, AutoProcessor
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from models.smolVLM import SmolVLM, SmolVLMConfig  # noqa: E402
+
+DEFAULT_PROMPT = "Summarise the scene in a few words."
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--hf-model", default="HuggingFaceTB/SmolVLM-256M-Base")
+    p.add_argument("--revision", default=None)
+    p.add_argument("--device", default="cuda", choices=["cuda", "cpu"])
+    p.add_argument("--dtype", default="float16", choices=["float32", "float16", "bfloat16"])
+    p.add_argument("--max-new-tokens", type=int, default=32)
+    p.add_argument("--temperature", type=float, default=0.8)
+    p.add_argument("--top-k", type=int, default=None)
+    p.add_argument("--prompt", default=None)
+    p.add_argument("--image", default=None, help="path to an RGB image (defaults to a grey square)")
+    p.add_argument("--local-files-only", action="store_true")
+    p.add_argument("--trust-remote-code", action="store_true")
+    return p.parse_args()
+
+
+def build_prompt(processor: AutoProcessor, text: str) -> str:
+    bos = processor.tokenizer.bos_token or ""
+    image_token = getattr(processor, "image_token", "<image>")
+    terminator = processor.tokenizer.unk_token or ""
+    return f"{bos}User:{image_token}{text}{terminator}Assistant:"
+
+
+def load_image(path: Optional[str]) -> Image.Image:
+    if path is None:
+        return Image.new("RGB", (512, 512), color=(180, 180, 180))
+    return Image.open(path).convert("RGB")
+
+
+def main() -> None:
+    args = parse_args()
+    device = torch.device(args.device if (args.device == "cpu" or torch.cuda.is_available()) else "cpu")
+    dtype = {"float32": torch.float32, "float16": torch.float16, "bfloat16": torch.bfloat16}[args.dtype]
+
+    hf_cfg = AutoConfig.from_pretrained(
+        args.hf_model,
+        revision=args.revision,
+        local_files_only=args.local_files_only,
+        trust_remote_code=args.trust_remote_code,
+    )
+    processor = AutoProcessor.from_pretrained(
+        args.hf_model,
+        revision=args.revision,
+        local_files_only=args.local_files_only,
+        trust_remote_code=args.trust_remote_code,
+    )
+
+    prompt_text = args.prompt if args.prompt is not None else DEFAULT_PROMPT
+    prompt = build_prompt(processor, prompt_text)
+    image = load_image(args.image)
+    proc_inputs = processor(
+        text=[prompt],
+        images=[image],
+        padding=True,
+        return_tensors="pt",
+    )
+
+    input_ids = proc_inputs["input_ids"].to(device)
+    attention_mask = proc_inputs["attention_mask"].to(device)
+    pixel_values = proc_inputs["pixel_values"].to(device=device, dtype=dtype)
+    pixel_attention_mask = proc_inputs["pixel_attention_mask"].to(device)
+
+    smol_cfg = SmolVLMConfig.from_hf_config(hf_cfg)
+    local_model = SmolVLM(smol_cfg).to(device=device, dtype=dtype).eval()
+    hf_model = AutoModelForVision2Seq.from_pretrained(
+        args.hf_model,
+        revision=args.revision,
+        local_files_only=args.local_files_only,
+        trust_remote_code=args.trust_remote_code,
+        torch_dtype=dtype,
+        device_map={"": device.type},
+    ).eval()
+
+    local_model.load_hf_state_dict(hf_model.state_dict(), strict=False, verbose=True, dtype=dtype, device=device)
+
+    with torch.no_grad():
+        local_ids = local_model.generate(
+            input_ids,
+            pixel_values=pixel_values,
+            pixel_attention_mask=pixel_attention_mask,
+            max_new_tokens=args.max_new_tokens,
+            temperature=args.temperature,
+            top_k=args.top_k,
+        )
+        hf_ids = hf_model.generate(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            pixel_values=pixel_values,
+            pixel_attention_mask=pixel_attention_mask,
+            max_new_tokens=args.max_new_tokens,
+            temperature=args.temperature,
+            top_k=args.top_k,
+        )
+
+    print("=== Prompt ===")
+    print(prompt_text)
+    print("\n=== Local ===")
+    print(processor.tokenizer.decode(local_ids[0], skip_special_tokens=True))
+    print("\n=== HF ===")
+    print(processor.tokenizer.decode(hf_ids[0], skip_special_tokens=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- split the SmolVLM language transformer across dedicated norms, rotary, attention, mlp, and block modules to mirror the modular SmolLM2 layout
- update the language model wrapper to stitch those modules together and expose them via the package __init__

## Testing
- python -m compileall models/smolVLM

------
https://chatgpt.com/codex/tasks/task_e_68c9f6a83830832b8f521d46c79d798e