### PR TITLE
Clarify rotary documentation and extend SmolVLM guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,12 @@
 # Project Philosophy (Core)
 
 - **NanoGPT**: heavily inspired by karpathy's [NanoGPT](https://github.com/karpathy/nanoGPT). 
-- **Minimal first**: smallest working pieces 
+- **Minimal first**: smallest working pieces
 - **One-screen modules**: prefer single, readable files.
 - **Config-driven**: experiments defined by configs, not code branches.
 - **Deterministic runs**: seeds + pinned versions.
+- **Education-first**: include comments that walk through tensor shapes, math, and reasoning so newcomers understand *why* each step exists.
+- **Descriptive names**: choose variable and function names that communicate intent, even if they are longer than typical PyTorch code.
 
 Repo Layout
 - models/      — core model(s)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 Inspired by [karpathy/nanoGPT](https://github.com/karpathy/nanoGPT) and the SmolLM/SmolVLM research threads (huggingface/smollm).
 
-Goal: To experiment quickly with VLMs (Vision+Language Models) in a minimal codebase. Using smolLM, smolVLM, and other models as reference.
+## Project philosophy
 
-Status: More coming soon.
-- smolLM implementation (no vision).
+- **Simplicity and readability are non-negotiable.** Each module should fit on a single screen and read like a step-by-step walkthrough of the underlying math.
+- **Education-first comments.** Inline notes should spell out tensor shapes, why operations are performed, and how they connect back to the transformer equations—aim the narration at curious beginners.
+- **Descriptive names.** Prefer variable names that communicate their role in the computation over brevity, even if they are longer than typical PyTorch code.
 
+## Goal
 
+Experiment quickly with VLMs (Vision+Language Models) in a minimal codebase while keeping the implementation approachable. We use SmolLM, SmolVLM, and related models as reference points.
 
+## Status
+
+- smolLM implementation (no vision) is available, more coming soon.

--- a/models/smolLM2/attention.py
+++ b/models/smolLM2/attention.py
@@ -1,4 +1,18 @@
-"""Multi-head attention used inside the SmolLM2 decoder blocks."""
+"""Multi-head attention used inside the SmolLM2 decoder blocks.
+
+The implementation intentionally mirrors the equations from the Transformer
+paper so that new readers can connect the PyTorch code with the math:
+
+* The query/key/value projections implement ``Q = XW_Q`` (and analogous
+  equations for ``K`` and ``V``) where ``X`` is the incoming hidden state.
+* Rotary position embeddings (RoPE) inject relative position information by
+  rotating the first and second halves of each head vector, which store the
+  cosine and sine parts of the complex representation.
+* Grouped-query attention is supported by duplicating the key/value heads when
+  ``n_heads`` is a multiple of ``n_kv_heads``.
+* The PyTorch ``scaled_dot_product_attention`` kernel performs
+  ``softmax(QK^T / sqrt(d_head))V`` in a numerically stable fused operation.
+"""
 from __future__ import annotations
 
 from typing import Optional
@@ -38,12 +52,13 @@ class SmolLM2Attention(nn.Module):
         """Return the attention output for a batch of hidden states.
 
         Args:
-            hidden_states: Input tensor of shape ``(batch, seq_len, hidden_size)``.
-            attn_mask: Optional attention mask broadcastable to
-                ``(batch, num_heads, seq_len, seq_len)``.  ``None`` means no
-                padding mask.
-            position_ids: Pre-computed rotary position ids of shape
-                ``(batch, seq_len)``.
+            hidden_states: ``(batch, seq_len, hidden_size)`` tensor containing the
+                activations produced by the previous layer.
+            attn_mask: Optional mask broadcastable to
+                ``(batch, num_heads, query_len, key_len)``. ``True`` entries mark
+                positions that should be ignored.
+            position_ids: ``(batch, seq_len)`` tensor with per-token positions
+                used by rotary embeddings.
         """
 
         batch_size, seq_len, _ = hidden_states.shape
@@ -51,30 +66,42 @@ class SmolLM2Attention(nn.Module):
         num_query_heads = self.cfg.n_heads
         num_kv_heads = self.cfg.n_kv_heads
 
-        # Linear projections -> [batch, seq_len, (#heads * head_dim)]
-        query = self.q_proj(hidden_states).view(batch_size, seq_len, num_query_heads, head_dim)
-        key = self.k_proj(hidden_states).view(batch_size, seq_len, num_kv_heads, head_dim)
-        value = self.v_proj(hidden_states).view(batch_size, seq_len, num_kv_heads, head_dim)
+        # Perform the learned linear projections.  After the view the tensor is
+        # shaped as [batch, seq_len, num_heads, head_dim] so each head owns a
+        # contiguous slice of the hidden dimension.
+        query_vectors = self.q_proj(hidden_states).view(
+            batch_size, seq_len, num_query_heads, head_dim
+        )
+        key_vectors = self.k_proj(hidden_states).view(
+            batch_size, seq_len, num_kv_heads, head_dim
+        )
+        value_vectors = self.v_proj(hidden_states).view(
+            batch_size, seq_len, num_kv_heads, head_dim
+        )
 
-        # Apply rotary position encodings before the attention score dot-product.
-        query, key = self.rotary(query, key, positions=position_ids)
+        # Apply RoPE so the dot-product between queries and keys encodes their
+        # relative position.  The vector is split into cosine and sine halves
+        # which are rotated by an angle derived from ``position_ids``.
+        query_vectors, key_vectors = self.rotary(query_vectors, key_vectors, positions=position_ids)
 
         # Grouped-query attention: duplicate key/value heads if there are fewer
         # kv-heads than query-heads.  repeat_interleave keeps tensors contiguous.
         if num_kv_heads != num_query_heads:
             repeat_factor = num_query_heads // num_kv_heads
-            key = key.repeat_interleave(repeat_factor, dim=2)
-            value = value.repeat_interleave(repeat_factor, dim=2)
+            key_vectors = key_vectors.repeat_interleave(repeat_factor, dim=2)
+            value_vectors = value_vectors.repeat_interleave(repeat_factor, dim=2)
 
-        # Switch to [batch, heads, seq_len, head_dim] for the attention kernel.
-        query = query.permute(0, 2, 1, 3)
-        key = key.permute(0, 2, 1, 3)
-        value = value.permute(0, 2, 1, 3)
+        # Rearrange to the kernel's preferred [batch, heads, seq_len, head_dim]
+        # layout.  ``permute`` only reorders views; ``contiguous`` below ensures
+        # the tensor is laid out as expected before the final projection.
+        query_vectors = query_vectors.permute(0, 2, 1, 3)
+        key_vectors = key_vectors.permute(0, 2, 1, 3)
+        value_vectors = value_vectors.permute(0, 2, 1, 3)
 
         attention_output = F.scaled_dot_product_attention(
-            query,
-            key,
-            value,
+            query_vectors,
+            key_vectors,
+            value_vectors,
             attn_mask=attn_mask,
             dropout_p=self.attn_dropout.p if self.training else 0.0,
             is_causal=True,

--- a/models/smolLM2/rotary.py
+++ b/models/smolLM2/rotary.py
@@ -8,25 +8,32 @@ import torch.nn as nn
 class RotaryEmbedding(nn.Module):
     """Apply RoPE in the LLaMA/SmolLM2 style.
 
-    The implementation mirrors Hugging Face's `RotaryEmbedding` module but keeps
-    the code small and well-commented for educational purposes.
+    We split the head dimension into two contiguous halves.  The first half acts
+    as the "cosine" coordinates, the second half provides the "sine" component.
+    Rotating these halves by an angle derived from the token position injects
+    relative offsets into the attention dot-product while preserving the vector
+    norm.  This mirrors the complex-number intuition often used to explain RoPE
+    without requiring the even/odd interleaving used in some implementations.
     """
 
     def __init__(self, head_dim: int, max_seq_len: int, base: float = 10000.0) -> None:
         super().__init__()
         self.head_dim = head_dim
-        # Pre-compute inverse frequencies for even positions.
+        # Pre-compute inverse frequencies for half of the features.  Each value
+        # corresponds to the ``1 / base^(i / head_dim)`` term in the RoPE
+        # formulation and is reused for both halves of the head vector.
         inv_freq = 1.0 / (base ** (torch.arange(0, head_dim, 2).float() / head_dim))
         self.register_buffer("inv_freq", inv_freq, persistent=False)
 
     @staticmethod
     def _rotate_half(x: torch.Tensor) -> torch.Tensor:
-        # Helper used to apply the complex rotation in a real-valued space.
+        """Swap and negate halves to emulate multiplication by ``i``."""
         x1 = x[..., : x.shape[-1] // 2]
         x2 = x[..., x.shape[-1] // 2 :]
         return torch.cat((-x2, x1), dim=-1)
 
     def _cos_sin(self, positions: torch.Tensor, device, dtype):
+        """Compute ``cos(theta)``/``sin(theta)`` for each position and feature pair."""
         freqs = torch.einsum("bt,d->btd", positions.to(torch.float32), self.inv_freq.to(device=device))
         emb = torch.cat([freqs, freqs], dim=-1)
         cos = emb.cos()
@@ -34,9 +41,18 @@ class RotaryEmbedding(nn.Module):
         return cos.to(dtype=dtype), sin.to(dtype=dtype)
 
     def forward(self, q: torch.Tensor, k: torch.Tensor, positions: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        # q, k: [B, T, H, head_dim]; positions: [B, T]
+        """Apply the rotary transformation to the query/key tensors.
+
+        Args:
+            q: ``(batch, seq_len, num_heads, head_dim)`` query tensor.
+            k: ``(batch, seq_len, num_heads, head_dim)`` key tensor.
+            positions: ``(batch, seq_len)`` integer tensor with absolute positions.
+        Returns:
+            Tuple ``(q_rotated, k_rotated)`` with the same shapes as the inputs.
+        """
+
         cos, sin = self._cos_sin(positions, q.device, q.dtype)
-        cos = cos.unsqueeze(2)  # broadcast across heads
+        cos = cos.unsqueeze(2)  # broadcast across attention heads
         sin = sin.unsqueeze(2)
         q = (q * cos) + (self._rotate_half(q) * sin)
         k = (k * cos) + (self._rotate_half(k) * sin)

--- a/models/smolVLM/attention.py
+++ b/models/smolVLM/attention.py
@@ -12,7 +12,20 @@ from .rotary import RotaryPositionalEmbedding
 
 
 class SmolVLMSelfAttention(nn.Module):
-    """Grouped-query causal self-attention."""
+    """Grouped-query causal self-attention layer.
+
+    The implementation mirrors the textbook transformer equations so beginners
+    can connect the code to the math:
+
+    * Query/key/value projections implement ``Q = XW_Q`` (and friends) where
+      ``X`` is the incoming hidden state matrix.
+    * Rotary position embeddings rotate the cosine and sine halves of each head
+      vector so the dot-product encodes relative position.
+    * When ``num_attention_heads`` is a multiple of ``num_key_value_heads`` we
+      duplicate key/value heads to emulate grouped-query attention.
+    * ``scaled_dot_product_attention`` performs ``softmax(QK^T / sqrt(d))V`` in
+      a fused, numerically stable kernel.
+    """
 
     def __init__(self, cfg: SmolVLMLanguageConfig) -> None:
         super().__init__()

--- a/models/smolVLM/block.py
+++ b/models/smolVLM/block.py
@@ -13,7 +13,17 @@ from .norms import SimpleRMSNorm
 
 
 class SmolVLMLanguageBlock(nn.Module):
-    """Pre-normalised transformer block (attention + feed-forward)."""
+    """Pre-normalised transformer block (attention + feed-forward).
+
+    The structure mirrors GPT-style decoder blocks:
+
+    1. Apply RMSNorm to stabilise the residual stream before the projections.
+    2. Run multi-head attention and add the result back to the stream.
+    3. Repeat the norm/transform/add pattern with the SwiGLU feed-forward MLP.
+
+    Keeping the steps separate makes it easier to trace tensor shapes and
+    understand where each transformation fits into the overall computation.
+    """
 
     def __init__(self, cfg: SmolVLMLanguageConfig) -> None:
         super().__init__()
@@ -29,12 +39,14 @@ class SmolVLMLanguageBlock(nn.Module):
         attention_mask: Optional[torch.Tensor],
         position_ids: torch.Tensor,
     ) -> torch.Tensor:
-        # Attention branch.
+        # Attention branch: normalise, transform, and add back to the residual
+        # stream.  ``hidden_states`` and ``attn_output`` both have shape
+        # [batch, seq_len, hidden_size].
         attn_input = self.ln_attn(hidden_states)
         attn_output = self.attn(attn_input, attention_mask=attention_mask, position_ids=position_ids)
         hidden_states = hidden_states + attn_output
 
-        # Feed-forward branch.
+        # Feed-forward branch mirrors the same pre-norm pattern.
         mlp_input = self.ln_mlp(hidden_states)
         mlp_output = self.mlp(mlp_input)
         return hidden_states + mlp_output


### PR DESCRIPTION
## Summary
- correct the RoPE documentation to describe the contiguous cosine/sine halves used in SmolLM2 and SmolVLM
- revert the attention code to the conventional `head_dim` terminology for easier cross-referencing with literature
- mirror the beginner-friendly docstrings and inline explanations across the SmolVLM attention, block, and MLP modules

## Testing
- python -m compileall models/smolLM2 models/smolVLM

------
https://chatgpt.com/codex/tasks/task_e_68cba4fc0ac8832bbf3e7e8819ece463