### PR TITLE
Fix LightEval runner by dropping unsupported do_sample argument

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -37,7 +37,7 @@ Each model has a dedicated helper under [`run_eval/`](./run_eval/) that wraps th
 
 - `vision_model=True` so LightEval uses the VLM transformer loader.
 - The SmolVLM chat template (`--use-chat-template`).
-- Deterministic decoding (`do_sample=false`, `temperature=0.0`, `top_p=1.0`, `max_new_tokens=64`).
+- Deterministic decoding (`temperature=0.0`, `top_p=1.0`, `max_new_tokens=64`) using LightEval's greedy default.
 - `dtype=bfloat16`, `device_map=auto`, and `trust_remote_code=True` to match the official configs.
 
 Running the baselines therefore boils down to:

--- a/eval/run_eval/smolvlm-256m-instruct/run.py
+++ b/eval/run_eval/smolvlm-256m-instruct/run.py
@@ -39,7 +39,6 @@ _BASE_MODEL_ARGS = {
     "device_map": "auto",
 }
 _BASE_GENERATION_ARGS = {
-    "do_sample": False,
     "temperature": 0.0,
     "top_p": 1.0,
     "max_new_tokens": 64,

--- a/eval/run_eval/smolvlm2-256m-video-instruct/run.py
+++ b/eval/run_eval/smolvlm2-256m-video-instruct/run.py
@@ -4,7 +4,7 @@
 The wrapper mirrors the configuration used in the SmolVLM2 baseline blog posts:
 
 - Zero-shot prompting with the official chat template.
-- Deterministic decoding (`do_sample=false`, `temperature=0.0`, `top_p=1.0`, `max_new_tokens=64`).
+- Deterministic decoding (`temperature=0.0`, `top_p=1.0`, `max_new_tokens=64`) via LightEval's greedy default.
 - Transformer VLM backend with bfloat16 weights and automatic device placement.
 """
 
@@ -35,7 +35,6 @@ _BASE_MODEL_ARGS = {
     "device_map": "auto",
 }
 _BASE_GENERATION_ARGS = {
-    "do_sample": False,
     "temperature": 0.0,
     "top_p": 1.0,
     "max_new_tokens": 64,


### PR DESCRIPTION
## Summary
- remove the `do_sample` flag from the LightEval generation parameters so the VLM configuration parses cleanly
- refresh documentation to note that deterministic decoding now relies on LightEval's greedy default

## Testing
- python eval/run_eval/smolvlm-256m-instruct/run.py --dry-run
- python eval/run_eval/smolvlm2-256m-video-instruct/run.py --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68d23004f020832babd708bfb3b2601c