### PR TITLE
Update LightEval launchers for new chat template interface

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -36,7 +36,7 @@ Each model has a dedicated helper under [`run_eval/`](./run_eval/) that wraps th
 `python -m lighteval accelerate` entrypoint.  The scripts set:
 
 - `vision_model=True` so LightEval uses the VLM transformer loader.
-- The SmolVLM chat template (`--use-chat-template`).
+- The SmolVLM chat template enforced through `override_chat_template=True` in the model args.
 - Deterministic decoding (`temperature=0.0`, `top_p=1.0`, `max_new_tokens=64`) using LightEval's greedy default.
 - `dtype=bfloat16`, `device_map=auto`, and `trust_remote_code=True` to match the official configs.
 

--- a/eval/run_eval/smolvlm-256m-instruct/run.py
+++ b/eval/run_eval/smolvlm-256m-instruct/run.py
@@ -5,7 +5,7 @@ The script composes the `python -m lighteval accelerate` call with the zero-shot
 settings requested in the baseline plan:
 
 - Deterministic decoding (no sampling, 64 new tokens, `temperature=0.0`, `top_p=1.0`).
-- Chat templating enabled via `--use-chat-template`.
+- Chat templating forced through `override_chat_template=True` in the model args.
 - Vision model loader (`--vision-model`) so image inputs are handled correctly.
 - bfloat16 weights with `device_map=auto` and `trust_remote_code=True`.
 
@@ -37,6 +37,7 @@ _BASE_MODEL_ARGS = {
     "batch_size": 1,
     "trust_remote_code": True,
     "device_map": "auto",
+    "override_chat_template": True,
 }
 _BASE_GENERATION_ARGS = {
     "temperature": 0.0,
@@ -135,7 +136,6 @@ def main() -> int:
         tasks_argument,
         "--output-dir",
         str(args.output_dir),
-        "--use-chat-template",
         "--vision-model",
         "--dataset-loading-processes",
         str(args.dataset_loading_processes),

--- a/eval/run_eval/smolvlm2-256m-video-instruct/run.py
+++ b/eval/run_eval/smolvlm2-256m-video-instruct/run.py
@@ -3,7 +3,7 @@
 
 The wrapper mirrors the configuration used in the SmolVLM2 baseline blog posts:
 
-- Zero-shot prompting with the official chat template.
+- Zero-shot prompting with the official chat template forced via `override_chat_template=True`.
 - Deterministic decoding (`temperature=0.0`, `top_p=1.0`, `max_new_tokens=64`) via LightEval's greedy default.
 - Transformer VLM backend with bfloat16 weights and automatic device placement.
 """
@@ -33,6 +33,7 @@ _BASE_MODEL_ARGS = {
     "batch_size": 1,
     "trust_remote_code": True,
     "device_map": "auto",
+    "override_chat_template": True,
 }
 _BASE_GENERATION_ARGS = {
     "temperature": 0.0,
@@ -129,7 +130,6 @@ def main() -> int:
         tasks_argument,
         "--output-dir",
         str(args.output_dir),
-        "--use-chat-template",
         "--vision-model",
         "--dataset-loading-processes",
         str(args.dataset_loading_processes),


### PR DESCRIPTION
## Summary
- update the SmolVLM evaluation launchers to rely on override_chat_template instead of the removed --use-chat-template flag
- document the new behavior in the evaluation README

## Testing
- python eval/run_eval/smolvlm-256m-instruct/run.py --dry-run
- python eval/run_eval/smolvlm2-256m-video-instruct/run.py --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68d365cdb56c832b9b8b9583e59cb83e