### PR TITLE
Add NanoEval suite runner with per-model presets

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -1,5 +1,38 @@
 # SmolVLM Baseline Evaluations
 
+## NanoEval (LightEval-free runners)
+
+`eval/nanoeval` now ships a config-driven alternative to LightEval.  Every
+benchmark exposes a single module that reads a YAML document, constructs the
+requested model, iterates over the dataset once, and writes:
+
+* `predictions.jsonl` — per-example rows for debugging.
+* `summary.json` — aggregate metrics, scoring parameters, and model metadata.
+* `metrics.csv` + `accuracy.png` — quick-look report of the primary score.
+
+All runtime options live in the YAML.  Point `NANOEVAL_CONFIG` at the file and
+launch the module:
+
+```bash
+export NANOEVAL_CONFIG=eval/nanoeval/configs/mmlu_tiny.yaml
+python -m eval.nanoeval.run_mmlu
+
+export NANOEVAL_CONFIG=eval/nanoeval/configs/hellaswag_tiny.yaml
+python -m eval.nanoeval.run_hellaswag
+
+# Requires a VLM checkpoint and the MMMU-Pro dataset access token.
+export NANOEVAL_CONFIG=eval/nanoeval/configs/mmmu_pro_smolvlm.yaml
+python -m eval.nanoeval.run_mmmu_pro
+```
+
+Suites under ``eval/nanoeval/suites`` bundle these tasks for a given checkpoint,
+writing a ``suite_summary.json`` alongside the per-task artefacts.  The smoke
+suite targets ``sshleifer/tiny-gpt2`` so it can run on CPU in under a minute.
+
+Copy the example configs in `eval/nanoeval/configs/`, adjust the `model` and
+`dataset` sections, and re-run.  Outputs default to `artifacts/nanoeval/<task>/`
+so experiments stay isolated from the repo tree.
+
 This directory wires up the LightEval baselines for the 256M SmolVLM checkpoints.  The goal is to
 reproduce the paper/blog zero-shot numbers on the LightEval-supported suites that cover both text
 and image reasoning tasks.

--- a/eval/nanoeval/README.md
+++ b/eval/nanoeval/README.md
@@ -1,0 +1,74 @@
+# NanoEval (config-first baseline loops)
+
+NanoEval keeps the original "one-screen" spirit of NanoGPT while shifting all
+task parameters into small YAML files.  Each benchmark has a single Python
+module that:
+
+1. Loads a :class:`ModelConfig` and dataset settings from the YAML document.
+2. Streams the corresponding Hugging Face dataset once.
+3. Records predictions, writes JSON/CSV summaries, and emits a quick-look bar
+   plot for the primary metric.
+
+The scripts deliberately avoid command-line flags—the only runtime input is the
+path to the YAML file, exposed via the ``NANOEVAL_CONFIG`` environment
+variable.  Copy an example config, tweak it to your checkpoint, and re-run.
+
+## Layout
+
+```
+common.py       # shared model wrapper + RNG seeding helpers
+config.py       # dataclasses + YAML loader used by every task
+reporting.py    # JSON/CSV/plot emitters for consistent artefacts
+prompts.py      # short zero-shot prompt templates
+run_mmlu.py     # MMLU macro-accuracy loop
+run_hellaswag.py# HellaSwag accuracy loop
+run_mmmu_pro.py # MMMU-Pro multimodal accuracy loop
+configs/        # example YAML configurations (copy + customise)
+```
+
+Outputs land in ``artifacts/nanoeval/<task>/`` by default.  The directory is
+git-ignored so you can iterate freely without polluting the repository.
+
+## Running an evaluation
+
+1. Copy one of the example YAML files (e.g. ``configs/mmlu_smolvlm.yaml``) and
+   edit the ``model``/``dataset`` sections as needed.
+2. Point ``NANOEVAL_CONFIG`` at that file and launch the module.
+
+```bash
+export NANOEVAL_CONFIG=eval/nanoeval/configs/mmlu_smolvlm.yaml
+python -m eval.nanoeval.run_mmlu
+
+export NANOEVAL_CONFIG=eval/nanoeval/configs/hellaswag_smolvlm.yaml
+python -m eval.nanoeval.run_hellaswag
+
+export NANOEVAL_CONFIG=eval/nanoeval/configs/mmmu_pro_smolvlm.yaml
+python -m eval.nanoeval.run_mmmu_pro
+```
+
+## Model-centric suites
+
+When you want to reproduce a paper-style table for a single checkpoint,
+coordinate the three tasks with a suite YAML under ``suites/``.  The suite file
+defines one model block and a list of task entries; each task inherits the
+shared model unless it overrides ``model`` locally.
+
+```bash
+export NANOEVAL_SUITE=eval/nanoeval/suites/smolvlm-256m-instruct.yaml
+python -m eval.nanoeval.suite
+```
+
+Running through ``suite.py`` writes a ``suite_summary.json`` next to the
+per-task artefacts so downstream automation can pick up all metrics in one
+place.  Copy ``suites/suite_smoke.yaml`` for a tiny, CPU-friendly example.
+
+Each run produces three artefacts in the configured ``report`` directory:
+
+* ``predictions.jsonl`` — one row per dataset example.
+* ``summary.json`` — aggregate metrics, scoring parameters, and model metadata.
+* ``metrics.csv`` & ``accuracy.png`` — tabular + visual view of the primary
+  score.
+
+All behaviour (e.g. log-likelihood scoring, maximum new tokens, per-subject
+subsets) is driven by the YAML file so experimenting with new checkpoints or
+decoding strategies is as simple as editing the config and re-running.

--- a/eval/nanoeval/__init__.py
+++ b/eval/nanoeval/__init__.py
@@ -1,0 +1,46 @@
+"""NanoEval: tiny, config-driven evaluation loops."""
+
+from .config import (
+    HellaSwagRunConfig,
+    MMMUProRunConfig,
+    MMLURunConfig,
+    ModelConfig,
+    ReportConfig,
+    ScoringConfig,
+    TaskConfig,
+    build_model_config,
+    build_task_config,
+    load_task_config,
+)
+from .run_hellaswag import run as run_hellaswag, run_from_yaml as run_hellaswag_from_yaml
+from .run_mmlu import run as run_mmlu, run_from_yaml as run_mmlu_from_yaml
+from .run_mmmu_pro import run as run_mmmu_pro, run_from_yaml as run_mmmu_pro_from_yaml
+from .suite import (
+    SuiteConfig,
+    load_suite_config,
+    run_suite,
+    run_suite_from_yaml,
+)
+
+__all__ = [
+    "ModelConfig",
+    "ScoringConfig",
+    "ReportConfig",
+    "MMLURunConfig",
+    "HellaSwagRunConfig",
+    "MMMUProRunConfig",
+    "TaskConfig",
+    "build_model_config",
+    "build_task_config",
+    "load_task_config",
+    "run_mmlu",
+    "run_mmlu_from_yaml",
+    "run_hellaswag",
+    "run_hellaswag_from_yaml",
+    "run_mmmu_pro",
+    "run_mmmu_pro_from_yaml",
+    "SuiteConfig",
+    "load_suite_config",
+    "run_suite",
+    "run_suite_from_yaml",
+]

--- a/eval/nanoeval/__init__.py
+++ b/eval/nanoeval/__init__.py
@@ -1,5 +1,7 @@
 """NanoEval: tiny, config-driven evaluation loops."""
 
+from typing import TYPE_CHECKING
+
 from .config import (
     HellaSwagRunConfig,
     MMMUProRunConfig,
@@ -12,15 +14,54 @@ from .config import (
     build_task_config,
     load_task_config,
 )
-from .run_hellaswag import run as run_hellaswag, run_from_yaml as run_hellaswag_from_yaml
-from .run_mmlu import run as run_mmlu, run_from_yaml as run_mmlu_from_yaml
-from .run_mmmu_pro import run as run_mmmu_pro, run_from_yaml as run_mmmu_pro_from_yaml
 from .suite import (
     SuiteConfig,
     load_suite_config,
     run_suite,
     run_suite_from_yaml,
 )
+
+if TYPE_CHECKING:  # pragma: no cover - imports only needed for type checkers
+    from .run_hellaswag import run as _run_hellaswag, run_from_yaml as _run_hellaswag_from_yaml
+    from .run_mmlu import run as _run_mmlu, run_from_yaml as _run_mmlu_from_yaml
+    from .run_mmmu_pro import run as _run_mmmu_pro, run_from_yaml as _run_mmmu_pro_from_yaml
+
+
+def run_mmlu(*args, **kwargs):
+    from .run_mmlu import run
+
+    return run(*args, **kwargs)
+
+
+def run_mmlu_from_yaml(*args, **kwargs):
+    from .run_mmlu import run_from_yaml
+
+    return run_from_yaml(*args, **kwargs)
+
+
+def run_hellaswag(*args, **kwargs):
+    from .run_hellaswag import run
+
+    return run(*args, **kwargs)
+
+
+def run_hellaswag_from_yaml(*args, **kwargs):
+    from .run_hellaswag import run_from_yaml
+
+    return run_from_yaml(*args, **kwargs)
+
+
+def run_mmmu_pro(*args, **kwargs):
+    from .run_mmmu_pro import run
+
+    return run(*args, **kwargs)
+
+
+def run_mmmu_pro_from_yaml(*args, **kwargs):
+    from .run_mmmu_pro import run_from_yaml
+
+    return run_from_yaml(*args, **kwargs)
+
 
 __all__ = [
     "ModelConfig",

--- a/eval/nanoeval/common.py
+++ b/eval/nanoeval/common.py
@@ -1,0 +1,158 @@
+"""Shared runtime utilities for the NanoEval tasks.
+
+The repository aims for "one-screen" evaluation scripts.  Everything that would
+otherwise be duplicated between the MMLU, HellaSwag, and MMMU-Pro runners lives
+here: device/precision handling, deterministic seeding, and the tiny wrappers
+around Hugging Face models used to score multiple-choice prompts.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List, Sequence
+
+import torch
+import torch.nn.functional as F
+from transformers import (
+    AutoModelForCausalLM,
+    AutoModelForVision2Seq,
+    AutoProcessor,
+    AutoTokenizer,
+)
+
+from .config import ModelConfig
+
+LETTER4: tuple[str, ...] = ("A", "B", "C", "D")
+LETTER10: tuple[str, ...] = LETTER4 + ("E", "F", "G", "H", "I", "J")
+
+_DTYPE_LOOKUP = {
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+    "float32": torch.float32,
+}
+
+
+def set_seed(seed: int) -> None:
+    """Seed all torch RNGs so greedy decoding stays deterministic."""
+
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def _resolve_device(requested: str) -> str:
+    """Return the actual device to run on given the user's preference."""
+
+    if requested.startswith("cuda") and torch.cuda.is_available():
+        return requested
+    return "cpu"
+
+
+class SimpleModel:
+    """Minimal wrapper around either a text LLM or a vision-language model."""
+
+    def __init__(self, cfg: ModelConfig) -> None:
+        self.cfg = cfg
+        self.device = _resolve_device(cfg.device)
+        torch_dtype = _DTYPE_LOOKUP.get(cfg.dtype, torch.float16)
+
+        if cfg.is_vlm:
+            self.processor = AutoProcessor.from_pretrained(
+                cfg.model_id, trust_remote_code=cfg.trust_remote_code
+            )
+            model_kwargs = {"torch_dtype": torch_dtype}
+            if self.device.startswith("cuda") and cfg.attn_impl:
+                model_kwargs["_attn_implementation"] = cfg.attn_impl
+            self.model = AutoModelForVision2Seq.from_pretrained(
+                cfg.model_id, **model_kwargs
+            ).to(self.device)
+            self.tokenizer = None
+        else:
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                cfg.model_id, trust_remote_code=cfg.trust_remote_code
+            )
+            if self.tokenizer.pad_token is None:
+                self.tokenizer.pad_token = self.tokenizer.eos_token
+            self.model = AutoModelForCausalLM.from_pretrained(
+                cfg.model_id, torch_dtype=torch_dtype
+            ).to(self.device)
+            self.processor = None
+
+        self.model.eval()
+
+    # --------------------------------------------------------------------- text
+    @torch.no_grad()
+    def generate_letter_text(
+        self,
+        prompt: str,
+        allowed_letters: Sequence[str],
+        max_new_tokens: int,
+    ) -> str:
+        """Greedily decode a short answer and return the first valid letter."""
+
+        if self.processor is not None:
+            raise RuntimeError("Vision-language models must use generate_letter_vlm")
+        encoded = self.tokenizer(prompt, return_tensors="pt").to(self.device)
+        output_ids = self.model.generate(
+            **encoded,
+            do_sample=False,
+            max_new_tokens=max_new_tokens,
+        )
+        decoded = self.tokenizer.decode(output_ids[0], skip_special_tokens=True)
+        match = re.search(r"[A-J]", decoded)
+        allowed = set(allowed_letters)
+        return match.group(0) if match and match.group(0) in allowed else ""
+
+    @torch.no_grad()
+    def rank_log_likelihood(self, prompt: str, options: Sequence[str]) -> int:
+        """Return the index of the option with the highest summed log-prob."""
+
+        if self.processor is not None:
+            raise RuntimeError("Log-likelihood scoring only applies to text models")
+
+        scores: List[float] = []
+        prompt_ids = self.tokenizer.encode(prompt, add_special_tokens=False)
+        for candidate in options:
+            option_ids = self.tokenizer.encode(" " + candidate, add_special_tokens=False)
+            input_ids = torch.tensor([prompt_ids + option_ids], device=self.device)
+            outputs = self.model(input_ids=input_ids)
+            logits = outputs.logits[:, :-1, :]
+            targets = input_ids[:, 1:]
+            log_probs = F.log_softmax(logits, dim=-1)
+            gathered = log_probs.gather(-1, targets.unsqueeze(-1)).squeeze(-1)
+            scores.append(gathered[0, -len(option_ids) :].sum().item())
+        best_index = max(range(len(options)), key=scores.__getitem__)
+        return int(best_index)
+
+    # ---------------------------------------------------------------------- vlm
+    @torch.no_grad()
+    def generate_letter_vlm(
+        self,
+        messages: Sequence[dict],
+        images: Sequence[object],
+        allowed_letters: Sequence[str],
+        max_new_tokens: int,
+    ) -> str:
+        """Mirror chat-style prompting for VLMs such as SmolVLM."""
+
+        if self.processor is None:
+            raise RuntimeError("Text models must use generate_letter_text")
+        prompt = self.processor.apply_chat_template(
+            list(messages), add_generation_prompt=True
+        )
+        inputs = self.processor(
+            text=prompt,
+            images=list(images) if images else None,
+            return_tensors="pt",
+        ).to(self.device)
+        output_ids = self.model.generate(
+            **inputs,
+            do_sample=False,
+            max_new_tokens=max_new_tokens,
+        )
+        decoded = self.processor.batch_decode(output_ids, skip_special_tokens=True)[0]
+        match = re.search(r"[A-J]", decoded)
+        allowed = set(allowed_letters)
+        return match.group(0) if match and match.group(0) in allowed else ""
+
+
+__all__ = ["LETTER4", "LETTER10", "set_seed", "SimpleModel"]

--- a/eval/nanoeval/common.py
+++ b/eval/nanoeval/common.py
@@ -15,7 +15,7 @@ import torch
 import torch.nn.functional as F
 from transformers import (
     AutoModelForCausalLM,
-    AutoModelForVision2Seq,
+    AutoModelForImageTextToText,
     AutoProcessor,
     AutoTokenizer,
 )
@@ -59,10 +59,10 @@ class SimpleModel:
             self.processor = AutoProcessor.from_pretrained(
                 cfg.model_id, trust_remote_code=cfg.trust_remote_code
             )
-            model_kwargs = {"torch_dtype": torch_dtype}
+            model_kwargs = {"dtype": torch_dtype}
             if self.device.startswith("cuda") and cfg.attn_impl:
                 model_kwargs["_attn_implementation"] = cfg.attn_impl
-            self.model = AutoModelForVision2Seq.from_pretrained(
+            self.model = AutoModelForImageTextToText.from_pretrained(
                 cfg.model_id, **model_kwargs
             ).to(self.device)
             self.tokenizer = None
@@ -73,7 +73,7 @@ class SimpleModel:
             if self.tokenizer.pad_token is None:
                 self.tokenizer.pad_token = self.tokenizer.eos_token
             self.model = AutoModelForCausalLM.from_pretrained(
-                cfg.model_id, torch_dtype=torch_dtype
+                cfg.model_id, dtype=torch_dtype
             ).to(self.device)
             self.processor = None
 

--- a/eval/nanoeval/config.py
+++ b/eval/nanoeval/config.py
@@ -1,0 +1,249 @@
+"""Dataclasses describing the YAML configuration for NanoEval tasks."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Mapping, Sequence
+
+import yaml
+
+
+@dataclass
+class ModelConfig:
+    """Configuration needed to load a Hugging Face model."""
+
+    model_id: str
+    is_vlm: bool = False
+    dtype: str = "bfloat16"
+    device: str = "cuda"
+    trust_remote_code: bool = True
+    attn_impl: str | None = None
+
+
+@dataclass
+class ScoringConfig:
+    """Options controlling how answers are generated or scored."""
+
+    strategy: Literal["gen_letter", "rank_ll"] = "gen_letter"
+    max_new_tokens: int = 8
+    seed: int = 123
+
+
+@dataclass
+class ReportConfig:
+    """Where to store predictions, summaries, and diagnostic plots."""
+
+    output_dir: Path
+    summary_filename: str = "summary.json"
+    predictions_filename: str = "predictions.jsonl"
+    table_filename: str = "metrics.csv"
+    plot_filename: str = "accuracy.png"
+    save_predictions: bool = True
+    save_table: bool = True
+    save_plot: bool = True
+
+
+@dataclass
+class MMLUDatasetConfig:
+    split: str = "test"
+    subjects: Sequence[str] | None = None
+    subset_size: int | None = None
+
+
+@dataclass
+class HellaSwagDatasetConfig:
+    split: Literal["validation", "test"] = "validation"
+    subset_size: int | None = None
+
+
+@dataclass
+class MMMUProDatasetConfig:
+    subset_name: Literal["standard (10 options)", "standard (4 options)", "vision"] = (
+        "standard (10 options)"
+    )
+    split: str = "test"
+    subset_size: int | None = None
+
+
+@dataclass
+class MMLURunConfig:
+    task: Literal["mmlu"]
+    model: ModelConfig
+    dataset: MMLUDatasetConfig = field(default_factory=MMLUDatasetConfig)
+    scoring: ScoringConfig = field(default_factory=ScoringConfig)
+    report: ReportConfig = field(
+        default_factory=lambda: ReportConfig(Path("artifacts/nanoeval/mmlu"))
+    )
+
+
+@dataclass
+class HellaSwagRunConfig:
+    task: Literal["hellaswag"]
+    model: ModelConfig
+    dataset: HellaSwagDatasetConfig = field(default_factory=HellaSwagDatasetConfig)
+    scoring: ScoringConfig = field(default_factory=ScoringConfig)
+    report: ReportConfig = field(
+        default_factory=lambda: ReportConfig(Path("artifacts/nanoeval/hellaswag"))
+    )
+
+
+@dataclass
+class MMMUProRunConfig:
+    task: Literal["mmmu_pro"]
+    model: ModelConfig
+    dataset: MMMUProDatasetConfig = field(default_factory=MMMUProDatasetConfig)
+    scoring: ScoringConfig = field(default_factory=ScoringConfig)
+    report: ReportConfig = field(
+        default_factory=lambda: ReportConfig(Path("artifacts/nanoeval/mmmu_pro"))
+    )
+
+
+TaskConfig = MMLURunConfig | HellaSwagRunConfig | MMMUProRunConfig
+
+
+def _ensure_report_config(
+    task: str, data: Mapping[str, Any], default_dir: Path | None = None
+) -> ReportConfig:
+    output_dir_raw = data.get("output_dir")
+    if output_dir_raw is not None:
+        target_dir = Path(str(output_dir_raw))
+    elif default_dir is not None:
+        target_dir = Path(default_dir)
+    else:
+        target_dir = Path("artifacts") / "nanoeval" / task
+    return ReportConfig(
+        output_dir=target_dir,
+        summary_filename=data.get("summary_filename", "summary.json"),
+        predictions_filename=data.get("predictions_filename", "predictions.jsonl"),
+        table_filename=data.get("table_filename", "metrics.csv"),
+        plot_filename=data.get("plot_filename", "accuracy.png"),
+        save_predictions=bool(data.get("save_predictions", True)),
+        save_table=bool(data.get("save_table", True)),
+        save_plot=bool(data.get("save_plot", True)),
+    )
+
+
+def build_model_config(data: Mapping[str, Any]) -> ModelConfig:
+    return ModelConfig(
+        model_id=data["model_id"],
+        is_vlm=bool(data.get("is_vlm", False)),
+        dtype=str(data.get("dtype", "bfloat16")),
+        device=str(data.get("device", "cuda")),
+        trust_remote_code=bool(data.get("trust_remote_code", True)),
+        attn_impl=data.get("attn_impl"),
+    )
+
+
+def _build_scoring_config(data: Mapping[str, Any] | None) -> ScoringConfig:
+    if not data:
+        return ScoringConfig()
+    return ScoringConfig(
+        strategy=str(data.get("strategy", "gen_letter")),
+        max_new_tokens=int(data.get("max_new_tokens", 8)),
+        seed=int(data.get("seed", 123)),
+    )
+
+
+def _build_mmlu_dataset(data: Mapping[str, Any] | None) -> MMLUDatasetConfig:
+    if not data:
+        return MMLUDatasetConfig()
+    subjects = data.get("subjects")
+    if isinstance(subjects, str):
+        subjects = [subjects]
+    elif subjects is not None and not isinstance(subjects, Sequence):
+        raise TypeError("`subjects` must be a sequence of subject names or omitted")
+    return MMLUDatasetConfig(
+        split=str(data.get("split", "test")),
+        subjects=tuple(subjects) if subjects else None,
+        subset_size=(int(data["subset_size"]) if data.get("subset_size") is not None else None),
+    )
+
+
+def _build_hellaswag_dataset(data: Mapping[str, Any] | None) -> HellaSwagDatasetConfig:
+    if not data:
+        return HellaSwagDatasetConfig()
+    subset_raw = data.get("subset_size")
+    return HellaSwagDatasetConfig(
+        split=str(data.get("split", "validation")),
+        subset_size=(int(subset_raw) if subset_raw is not None else None),
+    )
+
+
+def _build_mmmu_dataset(data: Mapping[str, Any] | None) -> MMMUProDatasetConfig:
+    if not data:
+        return MMMUProDatasetConfig()
+    subset_raw = data.get("subset_size")
+    return MMMUProDatasetConfig(
+        subset_name=str(data.get("subset_name", "standard (10 options)")),
+        split=str(data.get("split", "test")),
+        subset_size=(int(subset_raw) if subset_raw is not None else None),
+    )
+
+
+def load_task_config(path: Path) -> TaskConfig:
+    """Parse ``path`` into the strongly-typed configuration objects."""
+
+    with Path(path).open("r", encoding="utf-8") as handle:
+        payload: Mapping[str, Any] = yaml.safe_load(handle)
+
+    task_type = payload.get("task")
+    if task_type not in {"mmlu", "hellaswag", "mmmu_pro"}:
+        raise ValueError("Config must set task to 'mmlu', 'hellaswag', or 'mmmu_pro'")
+
+    return build_task_config(payload)
+
+
+def build_task_config(
+    payload: Mapping[str, Any],
+    *,
+    default_model: ModelConfig | None = None,
+    default_report_dir: Path | None = None,
+) -> TaskConfig:
+    """Construct a :class:`TaskConfig` from a mapping.
+
+    ``load_task_config`` uses this helper for single-task YAML files, while the
+    suite runner reuses it to compose multiple tasks that share one model.
+    """
+
+    task_type = payload.get("task")
+    if task_type not in {"mmlu", "hellaswag", "mmmu_pro"}:
+        raise ValueError("Config must set task to 'mmlu', 'hellaswag', or 'mmmu_pro'")
+
+    model_payload = payload.get("model")
+    if model_payload is not None:
+        model = build_model_config(model_payload)
+    elif default_model is not None:
+        model = default_model
+    else:
+        raise ValueError("Task entry is missing 'model' configuration")
+
+    scoring = _build_scoring_config(payload.get("scoring"))
+    report = _ensure_report_config(task_type, payload.get("report", {}), default_report_dir)
+
+    if task_type == "mmlu":
+        dataset = _build_mmlu_dataset(payload.get("dataset"))
+        return MMLURunConfig(task="mmlu", model=model, dataset=dataset, scoring=scoring, report=report)
+    if task_type == "hellaswag":
+        dataset = _build_hellaswag_dataset(payload.get("dataset"))
+        return HellaSwagRunConfig(
+            task="hellaswag", model=model, dataset=dataset, scoring=scoring, report=report
+        )
+    dataset = _build_mmmu_dataset(payload.get("dataset"))
+    return MMMUProRunConfig(task="mmmu_pro", model=model, dataset=dataset, scoring=scoring, report=report)
+
+
+__all__ = [
+    "ModelConfig",
+    "ScoringConfig",
+    "ReportConfig",
+    "MMLUDatasetConfig",
+    "HellaSwagDatasetConfig",
+    "MMMUProDatasetConfig",
+    "MMLURunConfig",
+    "HellaSwagRunConfig",
+    "MMMUProRunConfig",
+    "TaskConfig",
+    "load_task_config",
+    "build_model_config",
+    "build_task_config",
+]

--- a/eval/nanoeval/configs/hellaswag_smolvlm.yaml
+++ b/eval/nanoeval/configs/hellaswag_smolvlm.yaml
@@ -1,0 +1,25 @@
+# HellaSwag zero-shot evaluation using the text-only path of SmolVLM.
+task: hellaswag
+model:
+  model_id: HuggingFaceTB/SmolVLM-256M-Instruct
+  is_vlm: false
+  dtype: bfloat16
+  device: cuda
+  trust_remote_code: true
+  attn_impl: flash_attention_2
+scoring:
+  strategy: rank_ll
+  max_new_tokens: 8
+  seed: 123
+report:
+  output_dir: artifacts/nanoeval/hellaswag/smolvlm-256m
+  summary_filename: summary.json
+  predictions_filename: predictions.jsonl
+  table_filename: metrics.csv
+  plot_filename: accuracy.png
+  save_predictions: true
+  save_table: true
+  save_plot: true
+dataset:
+  split: validation
+  subset_size: null

--- a/eval/nanoeval/configs/hellaswag_tiny.yaml
+++ b/eval/nanoeval/configs/hellaswag_tiny.yaml
@@ -1,0 +1,25 @@
+# CPU-friendly smoke test config for HellaSwag.
+task: hellaswag
+model:
+  model_id: sshleifer/tiny-gpt2
+  is_vlm: false
+  dtype: float32
+  device: cpu
+  trust_remote_code: false
+  attn_impl: null
+scoring:
+  strategy: rank_ll
+  max_new_tokens: 4
+  seed: 7
+report:
+  output_dir: artifacts/nanoeval/hellaswag/tiny-gpt2
+  summary_filename: summary.json
+  predictions_filename: predictions.jsonl
+  table_filename: metrics.csv
+  plot_filename: accuracy.png
+  save_predictions: true
+  save_table: true
+  save_plot: false
+dataset:
+  split: validation
+  subset_size: 3

--- a/eval/nanoeval/configs/mmlu_smolvlm.yaml
+++ b/eval/nanoeval/configs/mmlu_smolvlm.yaml
@@ -1,0 +1,26 @@
+# Zero-shot MMLU run mirroring the SmolVLM LightEval baseline.
+task: mmlu
+model:
+  model_id: HuggingFaceTB/SmolVLM-256M-Instruct
+  is_vlm: false
+  dtype: bfloat16
+  device: cuda
+  trust_remote_code: true
+  attn_impl: flash_attention_2
+scoring:
+  strategy: gen_letter
+  max_new_tokens: 8
+  seed: 123
+report:
+  output_dir: artifacts/nanoeval/mmlu/smolvlm-256m
+  summary_filename: summary.json
+  predictions_filename: predictions.jsonl
+  table_filename: metrics.csv
+  plot_filename: accuracy.png
+  save_predictions: true
+  save_table: true
+  save_plot: true
+# Evaluate every MMLU subject on the test split.
+dataset:
+  split: test
+  subset_size: null

--- a/eval/nanoeval/configs/mmlu_tiny.yaml
+++ b/eval/nanoeval/configs/mmlu_tiny.yaml
@@ -1,0 +1,28 @@
+# CPU-friendly smoke test config using a toy GPT-2 checkpoint.
+task: mmlu
+model:
+  model_id: sshleifer/tiny-gpt2
+  is_vlm: false
+  dtype: float32
+  device: cpu
+  trust_remote_code: false
+  attn_impl: null
+scoring:
+  strategy: rank_ll
+  max_new_tokens: 4
+  seed: 7
+report:
+  output_dir: artifacts/nanoeval/mmlu/tiny-gpt2
+  summary_filename: summary.json
+  predictions_filename: predictions.jsonl
+  table_filename: metrics.csv
+  plot_filename: accuracy.png
+  save_predictions: true
+  save_table: true
+  save_plot: false
+# Limit to a couple of samples from one subject for quick checks.
+dataset:
+  split: test
+  subjects:
+    - high_school_mathematics
+  subset_size: 2

--- a/eval/nanoeval/configs/mmmu_pro_smolvlm.yaml
+++ b/eval/nanoeval/configs/mmmu_pro_smolvlm.yaml
@@ -1,0 +1,26 @@
+# MMMU-Pro standard (10 option) evaluation with SmolVLM.
+task: mmmu_pro
+model:
+  model_id: HuggingFaceTB/SmolVLM-256M-Instruct
+  is_vlm: true
+  dtype: bfloat16
+  device: cuda
+  trust_remote_code: true
+  attn_impl: flash_attention_2
+scoring:
+  strategy: gen_letter
+  max_new_tokens: 8
+  seed: 123
+report:
+  output_dir: artifacts/nanoeval/mmmu_pro/smolvlm-256m
+  summary_filename: summary.json
+  predictions_filename: predictions.jsonl
+  table_filename: metrics.csv
+  plot_filename: accuracy.png
+  save_predictions: true
+  save_table: true
+  save_plot: true
+dataset:
+  subset_name: "standard (10 options)"
+  split: test
+  subset_size: null

--- a/eval/nanoeval/prompts.py
+++ b/eval/nanoeval/prompts.py
@@ -1,0 +1,49 @@
+"""Prompt templates shared by the NanoEval runners."""
+
+MMLU_ZERO_SHOT = """\
+You are given a multiple-choice question. Choose the correct answer from A, B, C, or D.
+Reply using a single capital letter.
+
+Question:
+{question}
+
+Options:
+A. {A}
+B. {B}
+C. {C}
+D. {D}
+
+Answer:"""
+
+HELLASWAG_ZERO_SHOT = """\
+Choose the best ending (A, B, C, or D) that completes the context.
+Reply using a single capital letter.
+
+Context:
+{context}
+
+Endings:
+A. {A}
+B. {B}
+C. {C}
+D. {D}
+
+Answer:"""
+
+MMMU_VQA_ZERO_SHOT = """\
+You will see one or more images and a question with answer options.
+Reply using a single capital letter from this set: {letters}.
+
+Question:
+{question}
+
+Options:
+{options_block}
+
+Answer:"""
+
+__all__ = [
+    "HELLASWAG_ZERO_SHOT",
+    "MMLU_ZERO_SHOT",
+    "MMMU_VQA_ZERO_SHOT",
+]

--- a/eval/nanoeval/reporting.py
+++ b/eval/nanoeval/reporting.py
@@ -1,0 +1,81 @@
+"""Utility helpers for persisting NanoEval results and diagnostic plots."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+import matplotlib.pyplot as plt
+
+from .config import ReportConfig
+
+
+class ReportWriter:
+    """Persist predictions, aggregate metrics, and quick-look bar plots."""
+
+    def __init__(self, cfg: ReportConfig, title: str) -> None:
+        self.cfg = cfg
+        self.title = title
+        self.cfg.output_dir.mkdir(parents=True, exist_ok=True)
+
+    # ---------------------------------------------------------------- predictions
+    def write_predictions(self, rows: Iterable[Mapping[str, object]]) -> None:
+        if not self.cfg.save_predictions:
+            return
+        destination = self.cfg.output_dir / self.cfg.predictions_filename
+        with destination.open("w", encoding="utf-8") as handle:
+            for row in rows:
+                handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    # ------------------------------------------------------------------- summary
+    def write_summary(self, payload: Mapping[str, object]) -> None:
+        destination = self.cfg.output_dir / self.cfg.summary_filename
+        with destination.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, ensure_ascii=False)
+
+    # --------------------------------------------------------------------- table
+    def write_metrics_table(self, metrics: Sequence[tuple[str, float]]) -> None:
+        if not self.cfg.save_table:
+            return
+        destination = self.cfg.output_dir / self.cfg.table_filename
+        with destination.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.writer(handle)
+            writer.writerow(["label", "value"])
+            for label, value in metrics:
+                writer.writerow([label, value])
+
+    # ---------------------------------------------------------------------- plot
+    def plot_metrics(self, metrics: Sequence[tuple[str, float]]) -> None:
+        if not (self.cfg.save_plot and metrics):
+            return
+
+        destination = self.cfg.output_dir / self.cfg.plot_filename
+        labels = [label for label, _ in metrics]
+        values = [value for _, value in metrics]
+
+        fig_height = max(2.5, 0.45 * len(metrics) + 1.0)
+        fig, ax = plt.subplots(figsize=(9, fig_height))
+        positions = range(len(metrics))
+        ax.barh(positions, values, color="#4f81bd", alpha=0.85)
+        ax.set_yticks(list(positions))
+        ax.set_yticklabels(labels)
+        ax.set_xlabel("Accuracy")
+        ax.set_title(self.title)
+        ax.invert_yaxis()
+
+        for pos, value in zip(positions, values):
+            ax.text(value + 0.01, pos, f"{value:.3f}", va="center")
+
+        xmax = max(values)
+        if xmax <= 0:
+            xmax = 1.0
+        ax.set_xlim(0.0, min(1.0, xmax * 1.05) if xmax <= 1.0 else xmax * 1.05)
+
+        fig.tight_layout()
+        fig.savefig(destination, dpi=200, bbox_inches="tight")
+        plt.close(fig)
+
+
+__all__ = ["ReportWriter"]

--- a/eval/nanoeval/run_hellaswag.py
+++ b/eval/nanoeval/run_hellaswag.py
@@ -1,0 +1,102 @@
+"""HellaSwag evaluation driven entirely by YAML configs."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from .common import LETTER4, SimpleModel, set_seed
+from .config import HellaSwagRunConfig, load_task_config
+from .prompts import HELLASWAG_ZERO_SHOT
+from .reporting import ReportWriter
+
+
+def run(config: HellaSwagRunConfig) -> Dict[str, object]:
+    """Evaluate HellaSwag according to ``config`` and return a summary payload."""
+
+    set_seed(config.scoring.seed)
+    if config.scoring.strategy == "rank_ll" and config.model.is_vlm:
+        raise ValueError("Log-likelihood scoring requires a text-only model")
+
+    model = SimpleModel(config.model)
+    dataset = load_dataset("Rowan/hellaswag", split=config.dataset.split)
+    if config.dataset.subset_size is not None:
+        dataset = dataset.select(range(min(config.dataset.subset_size, len(dataset))))
+
+    correct = 0
+    rows: List[Dict[str, object]] = []
+
+    for index, example in enumerate(tqdm(dataset, desc=f"hellaswag:{config.dataset.split}")):
+        prompt = HELLASWAG_ZERO_SHOT.format(
+            context=example["ctx"],
+            A=example["endings"][0],
+            B=example["endings"][1],
+            C=example["endings"][2],
+            D=example["endings"][3],
+        )
+        gold_index = int(example["label"])
+
+        if config.scoring.strategy == "rank_ll":
+            predicted_index = model.rank_log_likelihood(prompt, example["endings"])
+        else:
+            letter = model.generate_letter_text(prompt, LETTER4, config.scoring.max_new_tokens)
+            predicted_index = LETTER4.index(letter) if letter in LETTER4 else -1
+
+        is_correct = predicted_index == gold_index
+        correct += int(is_correct)
+        rows.append(
+            {
+                "task": "hellaswag",
+                "index": index,
+                "gold": LETTER4[gold_index],
+                "prediction": LETTER4[predicted_index] if 0 <= predicted_index < 4 else "?",
+                "correct": bool(is_correct),
+            }
+        )
+
+    total = len(rows)
+    accuracy = correct / max(1, total)
+
+    writer = ReportWriter(config.report, title="HellaSwag accuracy")
+    writer.write_predictions(rows)
+    writer.write_summary(
+        {
+            "task": "hellaswag",
+            "accuracy": accuracy,
+            "total_examples": total,
+            "split": config.dataset.split,
+            "subset_size": config.dataset.subset_size,
+            "scoring": config.scoring.strategy,
+            "max_new_tokens": config.scoring.max_new_tokens,
+            "seed": config.scoring.seed,
+            "model_id": config.model.model_id,
+        }
+    )
+    writer.write_metrics_table([(config.dataset.split, accuracy)])
+    writer.plot_metrics([(config.dataset.split, accuracy)])
+
+    return {"accuracy": accuracy, "total_examples": total}
+
+
+def run_from_yaml(config_path: Path) -> Dict[str, object]:
+    cfg = load_task_config(config_path)
+    if not isinstance(cfg, HellaSwagRunConfig):
+        raise TypeError("HellaSwag runner received a configuration for a different task")
+    return run(cfg)
+
+
+def _main() -> None:
+    config_env = os.environ.get("NANOEVAL_CONFIG")
+    if config_env is None:
+        raise SystemExit("Set NANOEVAL_CONFIG to the path of a HellaSwag config YAML")
+    summary = run_from_yaml(Path(config_env))
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    _main()

--- a/eval/nanoeval/run_mmlu.py
+++ b/eval/nanoeval/run_mmlu.py
@@ -1,0 +1,203 @@
+"""Config-driven MMLU evaluation following the NanoGPT philosophy."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from .common import LETTER4, SimpleModel, set_seed
+from .config import MMLURunConfig, load_task_config
+from .reporting import ReportWriter
+from .prompts import MMLU_ZERO_SHOT
+
+SUBJECTS: Sequence[str] = (
+    "abstract_algebra",
+    "anatomy",
+    "astronomy",
+    "business_ethics",
+    "clinical_knowledge",
+    "college_biology",
+    "college_chemistry",
+    "college_computer_science",
+    "college_mathematics",
+    "college_medicine",
+    "college_physics",
+    "computer_security",
+    "conceptual_physics",
+    "econometrics",
+    "electrical_engineering",
+    "elementary_mathematics",
+    "formal_logic",
+    "global_facts",
+    "high_school_biology",
+    "high_school_chemistry",
+    "high_school_computer_science",
+    "high_school_european_history",
+    "high_school_geography",
+    "high_school_government_and_politics",
+    "high_school_macroeconomics",
+    "high_school_mathematics",
+    "high_school_microeconomics",
+    "high_school_physics",
+    "high_school_psychology",
+    "high_school_statistics",
+    "high_school_us_history",
+    "high_school_world_history",
+    "human_aging",
+    "human_sexuality",
+    "international_law",
+    "jurisprudence",
+    "logical_fallacies",
+    "machine_learning",
+    "management",
+    "marketing",
+    "medical_genetics",
+    "miscellaneous",
+    "moral_disputes",
+    "moral_scenarios",
+    "nutrition",
+    "philosophy",
+    "prehistory",
+    "professional_accounting",
+    "professional_law",
+    "professional_medicine",
+    "professional_psychology",
+    "public_relations",
+    "security_studies",
+    "sociology",
+    "us_foreign_policy",
+    "virology",
+    "world_religions",
+)
+
+
+def _select_subjects(config: MMLURunConfig) -> Sequence[str]:
+    requested = config.dataset.subjects
+    if requested:
+        return tuple(requested)
+    return SUBJECTS
+
+
+def _summarise(per_subject: Dict[str, Dict[str, int]]) -> Dict[str, object]:
+    macro = sum(item["correct"] / max(1, item["total"]) for item in per_subject.values()) / max(
+        1, len(per_subject)
+    )
+    total_correct = sum(item["correct"] for item in per_subject.values())
+    total_seen = sum(item["total"] for item in per_subject.values())
+    per_subject_accuracy = {
+        subject: {
+            "accuracy": counts["correct"] / max(1, counts["total"]),
+            "correct": counts["correct"],
+            "total": counts["total"],
+        }
+        for subject, counts in per_subject.items()
+    }
+    return {
+        "task": "mmlu",
+        "macro_accuracy": macro,
+        "micro_accuracy": total_correct / max(1, total_seen),
+        "total_examples": total_seen,
+        "per_subject": per_subject_accuracy,
+    }
+
+
+def run(config: MMLURunConfig) -> Dict[str, object]:
+    """Evaluate MMLU according to ``config`` and return the summary payload."""
+
+    set_seed(config.scoring.seed)
+    if config.scoring.strategy == "rank_ll" and config.model.is_vlm:
+        raise ValueError("Log-likelihood scoring requires a text-only model")
+
+    model = SimpleModel(config.model)
+    subjects = _select_subjects(config)
+    per_subject_counts: Dict[str, Dict[str, int]] = {}
+    records: List[Dict[str, object]] = []
+
+    for subject in subjects:
+        dataset = load_dataset("cais/mmlu", subject, split=config.dataset.split)
+        if config.dataset.subset_size is not None:
+            dataset = dataset.select(range(min(config.dataset.subset_size, len(dataset))))
+
+        correct = 0
+        total = 0
+        for index, example in enumerate(tqdm(dataset, desc=f"mmlu:{subject}", leave=False)):
+            prompt = MMLU_ZERO_SHOT.format(
+                question=example["question"],
+                A=example["choices"][0],
+                B=example["choices"][1],
+                C=example["choices"][2],
+                D=example["choices"][3],
+            )
+            gold = example["answer"]
+            if config.scoring.strategy == "rank_ll":
+                choice_index = model.rank_log_likelihood(prompt, example["choices"])
+                predicted = LETTER4[choice_index]
+            else:
+                predicted = (
+                    model.generate_letter_text(prompt, LETTER4, config.scoring.max_new_tokens)
+                    or "?"
+                )
+            is_correct = predicted == gold
+            correct += int(is_correct)
+            total += 1
+            records.append(
+                {
+                    "task": "mmlu",
+                    "subject": subject,
+                    "index": index,
+                    "gold": gold,
+                    "prediction": predicted,
+                    "correct": bool(is_correct),
+                }
+            )
+
+        per_subject_counts[subject] = {"correct": correct, "total": total}
+
+    summary = _summarise(per_subject_counts)
+
+    writer = ReportWriter(config.report, title="MMLU macro accuracy")
+    writer.write_predictions(records)
+    writer.write_summary(
+        {
+            **summary,
+            "scoring": config.scoring.strategy,
+            "max_new_tokens": config.scoring.max_new_tokens,
+            "seed": config.scoring.seed,
+            "subjects": list(subjects),
+            "split": config.dataset.split,
+            "subset_size": config.dataset.subset_size,
+            "model_id": config.model.model_id,
+        }
+    )
+    metrics = [
+        (subject.replace("_", " "), counts["correct"] / max(1, counts["total"]))
+        for subject, counts in per_subject_counts.items()
+    ]
+    writer.write_metrics_table(metrics)
+    writer.plot_metrics(metrics)
+
+    return summary
+
+
+def run_from_yaml(config_path: Path) -> Dict[str, object]:
+    cfg = load_task_config(config_path)
+    if not isinstance(cfg, MMLURunConfig):
+        raise TypeError("MMLU runner received a configuration for a different task")
+    return run(cfg)
+
+
+def _main() -> None:
+    config_env = os.environ.get("NANOEVAL_CONFIG")
+    if config_env is None:
+        raise SystemExit("Set NANOEVAL_CONFIG to the path of an MMLU config YAML")
+    summary = run_from_yaml(Path(config_env))
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    _main()

--- a/eval/nanoeval/run_mmmu_pro.py
+++ b/eval/nanoeval/run_mmmu_pro.py
@@ -59,7 +59,11 @@ def run(config: MMMUProRunConfig) -> Dict[str, object]:
 
     for example in tqdm(dataset, desc=f"mmmu_pro:{config.dataset.subset_name}"):
         options: List[str] = example["options"]
-        letters = LETTER10 if len(options) == 10 else LETTER4
+        if len(options) > len(LETTER10):
+            raise ValueError(
+                "MMMU-Pro examples cannot expose more than ten answer choices"
+            )
+        letters = LETTER4 if len(options) <= len(LETTER4) else LETTER10
         prompt = MMMU_VQA_ZERO_SHOT.format(
             letters=", ".join(letters[: len(options)]),
             question=example["question"],

--- a/eval/nanoeval/run_mmmu_pro.py
+++ b/eval/nanoeval/run_mmmu_pro.py
@@ -1,0 +1,134 @@
+"""Config-driven MMMU-Pro evaluation with optional vision inputs."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+from datasets import load_dataset
+from PIL import Image
+from tqdm import tqdm
+
+from .common import LETTER10, LETTER4, SimpleModel, set_seed
+from .config import MMMUProRunConfig, load_task_config
+from .prompts import MMMU_VQA_ZERO_SHOT
+from .reporting import ReportWriter
+
+IMAGE_COLUMNS = tuple(f"image_{idx}" for idx in range(1, 8))
+
+
+def _ensure_image(value) -> Image.Image:
+    if isinstance(value, Image.Image):
+        return value.convert("RGB")
+    if isinstance(value, dict) and "bytes" in value:
+        return Image.open(io.BytesIO(value["bytes"])).convert("RGB")
+    if isinstance(value, (bytes, bytearray)):
+        return Image.open(io.BytesIO(value)).convert("RGB")
+    if isinstance(value, str):
+        return Image.open(value).convert("RGB")
+    if hasattr(value, "numpy"):
+        return Image.fromarray(value.numpy()).convert("RGB")
+    raise TypeError(f"Unsupported image payload of type {type(value)!r}")
+
+
+def _collect_images(example) -> List[Image.Image]:
+    images: List[Image.Image] = []
+    for key in IMAGE_COLUMNS:
+        if key in example and example[key] is not None:
+            images.append(_ensure_image(example[key]))
+    return images
+
+
+def run(config: MMMUProRunConfig) -> Dict[str, object]:
+    """Evaluate MMMU-Pro according to ``config`` and return a summary payload."""
+
+    set_seed(config.scoring.seed)
+    if not config.model.is_vlm:
+        raise ValueError("MMMU-Pro requires a vision-language model")
+
+    model = SimpleModel(config.model)
+    dataset = load_dataset("MMMU/MMMU_Pro", name=config.dataset.subset_name, split=config.dataset.split)
+    if config.dataset.subset_size is not None:
+        dataset = dataset.select(range(min(config.dataset.subset_size, len(dataset))))
+
+    records: List[Dict[str, object]] = []
+    correct = 0
+
+    for example in tqdm(dataset, desc=f"mmmu_pro:{config.dataset.subset_name}"):
+        options: List[str] = example["options"]
+        letters = LETTER10 if len(options) == 10 else LETTER4
+        prompt = MMMU_VQA_ZERO_SHOT.format(
+            letters=", ".join(letters[: len(options)]),
+            question=example["question"],
+            options_block="\n".join(
+                f"{letters[idx]}. {choice}" for idx, choice in enumerate(options)
+            ),
+        )
+
+        images = _collect_images(example)
+        message_content = [{"type": "image"} for _ in images]
+        message_content.append({"type": "text", "text": prompt})
+        messages = [{"role": "user", "content": message_content}]
+
+        prediction = (
+            model.generate_letter_vlm(messages, images, letters, config.scoring.max_new_tokens)
+            or "?"
+        )
+        gold = example["answer"]
+        is_correct = prediction == gold
+        correct += int(is_correct)
+        records.append(
+            {
+                "task": "mmmu_pro",
+                "id": example.get("id", ""),
+                "gold": gold,
+                "prediction": prediction,
+                "correct": bool(is_correct),
+            }
+        )
+
+    total = len(records)
+    accuracy = correct / max(1, total)
+
+    writer = ReportWriter(config.report, title="MMMU-Pro accuracy")
+    writer.write_predictions(records)
+    writer.write_summary(
+        {
+            "task": "mmmu_pro",
+            "accuracy": accuracy,
+            "total_examples": total,
+            "subset_name": config.dataset.subset_name,
+            "split": config.dataset.split,
+            "subset_size": config.dataset.subset_size,
+            "scoring": config.scoring.strategy,
+            "max_new_tokens": config.scoring.max_new_tokens,
+            "seed": config.scoring.seed,
+            "model_id": config.model.model_id,
+        }
+    )
+    writer.write_metrics_table([(config.dataset.subset_name, accuracy)])
+    writer.plot_metrics([(config.dataset.subset_name, accuracy)])
+
+    return {"accuracy": accuracy, "total_examples": total}
+
+
+def run_from_yaml(config_path: Path) -> Dict[str, object]:
+    cfg = load_task_config(config_path)
+    if not isinstance(cfg, MMMUProRunConfig):
+        raise TypeError("MMMU-Pro runner received a configuration for a different task")
+    return run(cfg)
+
+
+def _main() -> None:
+    config_env = os.environ.get("NANOEVAL_CONFIG")
+    if config_env is None:
+        raise SystemExit("Set NANOEVAL_CONFIG to the path of an MMMU-Pro config YAML")
+    summary = run_from_yaml(Path(config_env))
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    _main()

--- a/eval/nanoeval/suite.py
+++ b/eval/nanoeval/suite.py
@@ -1,0 +1,114 @@
+"""Run multiple NanoEval tasks for a single model using one YAML file."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+import yaml
+
+from .config import ModelConfig, TaskConfig, build_model_config, build_task_config
+from .run_hellaswag import run as run_hellaswag
+from .run_mmlu import run as run_mmlu
+from .run_mmmu_pro import run as run_mmmu_pro
+
+
+@dataclass
+class SuiteConfig:
+    """Describe a bundle of evaluation tasks that share a base model."""
+
+    name: str
+    output_root: Path
+    model: ModelConfig
+    tasks: Sequence[TaskConfig]
+
+
+def _default_output_root(name: str) -> Path:
+    return Path("artifacts") / "nanoeval" / "suites" / name
+
+
+def load_suite_config(path: Path) -> SuiteConfig:
+    """Parse ``path`` into a :class:`SuiteConfig`."""
+
+    with Path(path).open("r", encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle)
+
+    if not isinstance(payload, dict):
+        raise TypeError("Suite YAML must contain a mapping")
+
+    suite_meta = payload.get("suite") or {}
+    name = str(suite_meta.get("name", Path(path).stem))
+
+    output_root_raw = suite_meta.get("output_root")
+    output_root = _default_output_root(name) if output_root_raw is None else Path(output_root_raw)
+
+    model_payload = payload.get("model")
+    if not model_payload:
+        raise ValueError("Suite config must provide a 'model' section")
+    model = build_model_config(model_payload)
+
+    task_entries = payload.get("tasks")
+    if not isinstance(task_entries, list) or not task_entries:
+        raise ValueError("Suite config must list at least one task")
+
+    tasks: List[TaskConfig] = []
+    for entry in task_entries:
+        if not isinstance(entry, dict):
+            raise TypeError("Each task entry must be a mapping")
+        task_cfg = build_task_config(entry, default_model=model, default_report_dir=None)
+        # Unless the user explicitly overrides ``output_dir`` we tuck the
+        # artefacts under ``<output_root>/<task-name>/``.
+        report_section = entry.get("report") if isinstance(entry.get("report"), dict) else {}
+        if "output_dir" not in report_section:
+            task_cfg.report.output_dir = output_root / task_cfg.task
+        tasks.append(task_cfg)
+
+    return SuiteConfig(name=name, output_root=output_root, model=model, tasks=tuple(tasks))
+
+
+def _run_task(task: TaskConfig) -> Dict[str, object]:
+    if task.task == "mmlu":  # type: ignore[comparison-overlap]
+        summary = run_mmlu(task)  # type: ignore[arg-type]
+    elif task.task == "hellaswag":
+        summary = run_hellaswag(task)  # type: ignore[arg-type]
+    else:
+        summary = run_mmmu_pro(task)  # type: ignore[arg-type]
+    return {"task": task.task, **summary}
+
+
+def run_suite(config: SuiteConfig) -> Sequence[Dict[str, object]]:
+    """Execute every task in ``config`` and persist a suite-level summary."""
+
+    summaries = [_run_task(task) for task in config.tasks]
+
+    config.output_root.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "suite": config.name,
+        "model_id": config.model.model_id,
+        "num_tasks": len(summaries),
+        "results": summaries,
+    }
+    summary_path = config.output_root / "suite_summary.json"
+    with summary_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+
+    return summaries
+
+
+def run_suite_from_yaml(path: Path) -> Sequence[Dict[str, object]]:
+    return run_suite(load_suite_config(path))
+
+
+def _main() -> None:
+    suite_env = os.environ.get("NANOEVAL_SUITE")
+    if suite_env is None:
+        raise SystemExit("Set NANOEVAL_SUITE to the path of a suite YAML file")
+    results = run_suite_from_yaml(Path(suite_env))
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    _main()

--- a/eval/nanoeval/suite.py
+++ b/eval/nanoeval/suite.py
@@ -11,9 +11,6 @@ from typing import Dict, List, Sequence
 import yaml
 
 from .config import ModelConfig, TaskConfig, build_model_config, build_task_config
-from .run_hellaswag import run as run_hellaswag
-from .run_mmlu import run as run_mmlu
-from .run_mmmu_pro import run as run_mmmu_pro
 
 
 @dataclass
@@ -71,10 +68,16 @@ def load_suite_config(path: Path) -> SuiteConfig:
 
 def _run_task(task: TaskConfig) -> Dict[str, object]:
     if task.task == "mmlu":  # type: ignore[comparison-overlap]
+        from .run_mmlu import run as run_mmlu
+
         summary = run_mmlu(task)  # type: ignore[arg-type]
     elif task.task == "hellaswag":
+        from .run_hellaswag import run as run_hellaswag
+
         summary = run_hellaswag(task)  # type: ignore[arg-type]
     else:
+        from .run_mmmu_pro import run as run_mmmu_pro
+
         summary = run_mmmu_pro(task)  # type: ignore[arg-type]
     return {"task": task.task, **summary}
 

--- a/eval/nanoeval/suites/smolvlm-256m-instruct.yaml
+++ b/eval/nanoeval/suites/smolvlm-256m-instruct.yaml
@@ -1,0 +1,33 @@
+suite:
+  name: smolvlm-256m-instruct
+  output_root: artifacts/nanoeval/suites/smolvlm-256m-instruct
+model:
+  model_id: HuggingFaceTB/SmolVLM-256M-Instruct
+  is_vlm: true
+  dtype: bfloat16
+  device: cuda
+  trust_remote_code: true
+  attn_impl: flash_attention_2
+tasks:
+  - task: mmlu
+    dataset:
+      split: test
+    scoring:
+      strategy: gen_letter
+      max_new_tokens: 8
+      seed: 123
+  - task: hellaswag
+    dataset:
+      split: validation
+    scoring:
+      strategy: gen_letter
+      max_new_tokens: 8
+      seed: 123
+  - task: mmmu_pro
+    dataset:
+      subset_name: "standard (10 options)"
+      split: test
+    scoring:
+      strategy: gen_letter
+      max_new_tokens: 16
+      seed: 123

--- a/eval/nanoeval/suites/smolvlm2-256m-video-instruct.yaml
+++ b/eval/nanoeval/suites/smolvlm2-256m-video-instruct.yaml
@@ -1,0 +1,33 @@
+suite:
+  name: smolvlm2-256m-video-instruct
+  output_root: artifacts/nanoeval/suites/smolvlm2-256m-video-instruct
+model:
+  model_id: HuggingFaceTB/SmolVLM2-256M-Video-Instruct
+  is_vlm: true
+  dtype: bfloat16
+  device: cuda
+  trust_remote_code: true
+  attn_impl: flash_attention_2
+tasks:
+  - task: mmlu
+    dataset:
+      split: test
+    scoring:
+      strategy: gen_letter
+      max_new_tokens: 8
+      seed: 123
+  - task: hellaswag
+    dataset:
+      split: validation
+    scoring:
+      strategy: gen_letter
+      max_new_tokens: 8
+      seed: 123
+  - task: mmmu_pro
+    dataset:
+      subset_name: "standard (10 options)"
+      split: test
+    scoring:
+      strategy: gen_letter
+      max_new_tokens: 16
+      seed: 123

--- a/eval/nanoeval/suites/suite_smoke.yaml
+++ b/eval/nanoeval/suites/suite_smoke.yaml
@@ -1,0 +1,27 @@
+suite:
+  name: smoke-text
+model:
+  model_id: sshleifer/tiny-gpt2
+  is_vlm: false
+  dtype: float32
+  device: cpu
+  trust_remote_code: false
+tasks:
+  - task: mmlu
+    dataset:
+      split: test
+      subjects:
+        - high_school_mathematics
+      subset_size: 4
+    scoring:
+      strategy: rank_ll
+      max_new_tokens: 4
+      seed: 123
+  - task: hellaswag
+    dataset:
+      split: validation
+      subset_size: 8
+    scoring:
+      strategy: rank_ll
+      max_new_tokens: 4
+      seed: 123

--- a/models/smolLM2/run_nanoeval_suite.py
+++ b/models/smolLM2/run_nanoeval_suite.py
@@ -1,0 +1,16 @@
+"""Run the NanoEval suite for the SmolVLM2 reference checkpoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from eval.nanoeval.suite import run_suite_from_yaml
+
+
+def main() -> None:
+    config = Path(__file__).resolve().parents[1] / "eval" / "nanoeval" / "suites" / "smolvlm2-256m-video-instruct.yaml"
+    run_suite_from_yaml(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/smolVLM/run_nanoeval_suite.py
+++ b/models/smolVLM/run_nanoeval_suite.py
@@ -1,0 +1,16 @@
+"""Kick off the NanoEval suite for the reference SmolVLM checkpoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from eval.nanoeval.suite import run_suite_from_yaml
+
+
+def main() -> None:
+    config = Path(__file__).resolve().parents[1] / "eval" / "nanoeval" / "suites" / "smolvlm-256m-instruct.yaml"
+    run_suite_from_yaml(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/smolLM2/README.md
+++ b/test/smolLM2/README.md
@@ -49,4 +49,6 @@ before reshaping; downstream values still match.)
 
 The other scripts (`compare_hf_vs_local.py`, `dump_first_diff_layer.py`, and
 `generate_smoke.py`) continue to work as small parity and sampling tools.  They
-now import the refactored package layout without modification.
+now import the refactored package layout without modification.  Use
+`run_nanoeval_suite.py` to execute the tiny ``suite_smoke.yaml`` configuration
+and check that the evaluation harness remains wired correctly.

--- a/test/smolLM2/run_nanoeval_suite.py
+++ b/test/smolLM2/run_nanoeval_suite.py
@@ -1,0 +1,16 @@
+"""Smoke-test the NanoEval suite using a tiny text model."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from eval.nanoeval.suite import run_suite_from_yaml
+
+
+def main() -> None:
+    config = Path(__file__).resolve().parents[2] / "eval" / "nanoeval" / "suites" / "suite_smoke.yaml"
+    run_suite_from_yaml(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/smolVLM/README.md
+++ b/test/smolVLM/README.md
@@ -11,6 +11,9 @@ quick sampling for the minimal implementation in `models/smolVLM/`.
   teacher-forced comparison for a text+image prompt.
 - `generate_smoke.py` — loads the weights and produces a short generated
   response to a tiny text+image input.
+- `run_nanoeval_suite.py` — executes the tiny ``suite_smoke.yaml`` config,
+  providing an end-to-end check that the config loader, report writer, and
+  scoring helpers work together.
 
 By default the scripts target `HuggingFaceTB/SmolVLM-256M-Base`, which is
 public.  Pass `--hf-model` to point at private or fine-tuned variants such as

--- a/test/smolVLM/run_nanoeval_suite.py
+++ b/test/smolVLM/run_nanoeval_suite.py
@@ -1,0 +1,16 @@
+"""Smoke-test the NanoEval suite using a tiny text model."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from eval.nanoeval.suite import run_suite_from_yaml
+
+
+def main() -> None:
+    config = Path(__file__).resolve().parents[2] / "eval" / "nanoeval" / "suites" / "suite_smoke.yaml"
+    run_suite_from_yaml(config)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a suite runner that chains multiple NanoEval tasks from a single YAML and records a suite-level summary
- extend the config helpers to reuse model/report defaults and ship suite presets for SmolVLM, SmolVLM2, and a tiny smoke run
- expose simple entry scripts under each model and matching smoke scripts in `test/` to exercise the new suite configs

## Testing
- python -m eval.nanoeval.suite


------
https://chatgpt.com/codex/tasks/task_e_68d4c489961c832b897168b8e714ce72