### PR TITLE
Add TextVQA and MME nanoeval runners

### DIFF
--- a/eval/nanoeval/README.md
+++ b/eval/nanoeval/README.md
@@ -23,6 +23,8 @@ prompts.py      # short zero-shot prompt templates
 run_mmlu.py     # MMLU macro-accuracy loop
 run_hellaswag.py# HellaSwag accuracy loop
 run_mmmu_pro.py # MMMU-Pro multimodal accuracy loop
+run_textvqa.py  # TextVQA short-answer accuracy with VQA scoring
+run_mme.py      # MME yes/no accuracy with per-category breakdown
 configs/        # example YAML configurations (copy + customise)
 ```
 
@@ -44,12 +46,20 @@ python -m eval.nanoeval.run_hellaswag
 
 export NANOEVAL_CONFIG=eval/nanoeval/configs/mmmu_pro_smolvlm.yaml
 python -m eval.nanoeval.run_mmmu_pro
+
+export NANOEVAL_CONFIG=eval/nanoeval/configs/textvqa_smolvlm.yaml
+python -m eval.nanoeval.run_textvqa
+
+export NANOEVAL_CONFIG=eval/nanoeval/configs/mme_smolvlm.yaml
+python -m eval.nanoeval.run_mme
 ```
 
-All three runners use log-likelihood ranking exclusively; the model scores each
-option and the highest-probability choice wins.  No parsing of generated letters
-is involved, and the only scoring parameter exposed in the YAML is the random
-seed that keeps sampling-free runs deterministic.
+The multiple-choice tasks (MMLU, HellaSwag, MMMU-Pro) use log-likelihood
+ranking exclusively; the model scores each option and the highest-probability
+choice wins.  TextVQA and MME rely on deterministic greedy generation via
+``SimpleModel.generate_text`` so that repeated runs with the same seed stay
+reproducible.  All tasks surface the random seed in the YAML so you can keep
+experiments deterministic.
 
 > **Tip**
 > MMMU-Pro requires `model.is_vlm: true` so the runner can feed images through

--- a/eval/nanoeval/__init__.py
+++ b/eval/nanoeval/__init__.py
@@ -3,13 +3,16 @@
 from typing import TYPE_CHECKING
 
 from .config import (
+    GenerationConfig,
     HellaSwagRunConfig,
+    MMERunConfig,
     MMMUProRunConfig,
     MMLURunConfig,
     ModelConfig,
     ReportConfig,
     ScoringConfig,
     TaskConfig,
+    TextVQARunConfig,
     build_model_config,
     build_task_config,
     load_task_config,
@@ -23,8 +26,10 @@ from .suite import (
 
 if TYPE_CHECKING:  # pragma: no cover - imports only needed for type checkers
     from .run_hellaswag import run as _run_hellaswag, run_from_yaml as _run_hellaswag_from_yaml
+    from .run_mme import run as _run_mme, run_from_yaml as _run_mme_from_yaml
     from .run_mmlu import run as _run_mmlu, run_from_yaml as _run_mmlu_from_yaml
     from .run_mmmu_pro import run as _run_mmmu_pro, run_from_yaml as _run_mmmu_pro_from_yaml
+    from .run_textvqa import run as _run_textvqa, run_from_yaml as _run_textvqa_from_yaml
 
 
 def run_mmlu(*args, **kwargs):
@@ -63,13 +68,40 @@ def run_mmmu_pro_from_yaml(*args, **kwargs):
     return run_from_yaml(*args, **kwargs)
 
 
+def run_textvqa(*args, **kwargs):
+    from .run_textvqa import run
+
+    return run(*args, **kwargs)
+
+
+def run_textvqa_from_yaml(*args, **kwargs):
+    from .run_textvqa import run_from_yaml
+
+    return run_from_yaml(*args, **kwargs)
+
+
+def run_mme(*args, **kwargs):
+    from .run_mme import run
+
+    return run(*args, **kwargs)
+
+
+def run_mme_from_yaml(*args, **kwargs):
+    from .run_mme import run_from_yaml
+
+    return run_from_yaml(*args, **kwargs)
+
+
 __all__ = [
     "ModelConfig",
     "ScoringConfig",
     "ReportConfig",
+    "GenerationConfig",
     "MMLURunConfig",
     "HellaSwagRunConfig",
     "MMMUProRunConfig",
+    "TextVQARunConfig",
+    "MMERunConfig",
     "TaskConfig",
     "build_model_config",
     "build_task_config",
@@ -80,6 +112,10 @@ __all__ = [
     "run_hellaswag_from_yaml",
     "run_mmmu_pro",
     "run_mmmu_pro_from_yaml",
+    "run_textvqa",
+    "run_textvqa_from_yaml",
+    "run_mme",
+    "run_mme_from_yaml",
     "SuiteConfig",
     "load_suite_config",
     "run_suite",

--- a/eval/nanoeval/common.py
+++ b/eval/nanoeval/common.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import random
 from string import ascii_uppercase
-from typing import List, Sequence
+from typing import Any, List, Mapping, Sequence
 
 import numpy as np
 import torch
@@ -106,6 +106,119 @@ class SimpleModel:
         self.model.eval()
 
     # --------------------------------------------------------------------- text
+    @torch.no_grad()
+    def generate_text(
+        self,
+        prompt: str | Sequence[Mapping[str, Any]],
+        *,
+        images: Sequence[object] | None = None,
+        max_new_tokens: int = 32,
+    ) -> str:
+        """Greedily decode a response for ``prompt``.
+
+        ``SimpleModel`` instances abstract over text-only causal LMs and
+        multimodal chat-style models.  ``generate_text`` accepts either a raw
+        string prompt (for text models) or a chat-style conversation
+        (``[{"role": ..., "content": ...}, ...]``) for VLMs.  The method always
+        performs deterministic greedy decoding so repeated calls with the same
+        seed produce identical outputs.
+        """
+
+        if max_new_tokens < 1:
+            raise ValueError("max_new_tokens must be at least 1")
+
+        tokenizer = self.tokenizer
+        if self.processor is None:
+            if not isinstance(prompt, str):
+                raise TypeError("Text models expect `prompt` to be a string")
+            # ``transformers`` tokenizers expose both ``__call__`` and ``encode``.
+            # ``SimpleModel`` supports either to keep dummy unit-test tokenizers
+            # lightweight.
+            tokenized_inputs: Mapping[str, torch.Tensor]
+            try:
+                tokenized_inputs = self.tokenizer(  # type: ignore[call-arg]
+                    prompt, return_tensors="pt"
+                )
+            except TypeError:
+                prompt_ids = self.tokenizer.encode(  # type: ignore[call-arg]
+                    prompt, add_special_tokens=False
+                )
+                tensor = torch.tensor([prompt_ids], dtype=torch.long)
+                tokenized_inputs = {
+                    "input_ids": tensor,
+                    "attention_mask": torch.ones_like(tensor),
+                }
+            inputs = {
+                name: value.to(self.device) if hasattr(value, "to") else value
+                for name, value in tokenized_inputs.items()
+            }
+        else:
+            images_list = list(images) if images is not None else []
+            if isinstance(prompt, str):
+                messages = [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": prompt,
+                            }
+                        ],
+                    }
+                ]
+            else:
+                messages = list(prompt)
+            convo_text = self.processor.apply_chat_template(  # type: ignore[arg-type]
+                messages, add_generation_prompt=True
+            )
+            batch_encoding = self.processor(  # type: ignore[call-arg]
+                text=convo_text,
+                images=images_list if images_list else None,
+                return_tensors="pt",
+            )
+            inputs = {
+                name: value.to(self.device) if hasattr(value, "to") else value
+                for name, value in batch_encoding.items()
+            }
+            tokenizer = getattr(self.processor, "tokenizer", tokenizer)
+
+        pad_token_id = None
+        if hasattr(self.model, "config"):
+            pad_token_id = getattr(self.model.config, "pad_token_id", None)
+            if pad_token_id is None:
+                pad_token_id = getattr(self.model.config, "eos_token_id", None)
+        if pad_token_id is None and tokenizer is not None:
+            pad_token_id = getattr(tokenizer, "pad_token_id", None)
+            if pad_token_id is None:
+                pad_token_id = getattr(tokenizer, "eos_token_id", None)
+
+        generated_ids = self.model.generate(  # type: ignore[call-arg]
+            **inputs,
+            max_new_tokens=int(max_new_tokens),
+            do_sample=False,
+            pad_token_id=pad_token_id,
+        )
+
+        if isinstance(generated_ids, torch.Tensor):
+            full_sequence = generated_ids
+        else:
+            full_sequence = torch.tensor(generated_ids, device=self.device)
+
+        input_length = inputs["input_ids"].shape[1]
+        new_token_ids = full_sequence[0, input_length:]
+        new_token_list = new_token_ids.tolist()
+
+        if tokenizer is not None and hasattr(tokenizer, "decode"):
+            text = tokenizer.decode(new_token_list, skip_special_tokens=True)  # type: ignore[arg-type]
+        elif hasattr(self.processor, "decode"):
+            text = self.processor.decode(new_token_list, skip_special_tokens=True)  # type: ignore[arg-type]
+        elif hasattr(self.processor, "batch_decode"):
+            text = self.processor.batch_decode([new_token_list], skip_special_tokens=True)[0]  # type: ignore[arg-type]
+        else:
+            raise RuntimeError("Could not find a decode method for generated tokens")
+
+        return text.strip()
+
     @torch.no_grad()
     def rank_log_likelihood(self, prompt: str, options: Sequence[str], normalize: bool = False) -> int:
         """Return the index of the option with the highest summed log-prob.

--- a/eval/nanoeval/configs/mme_smolvlm.yaml
+++ b/eval/nanoeval/configs/mme_smolvlm.yaml
@@ -1,0 +1,26 @@
+# MME yes/no evaluation with SmolVLM.
+task: mme
+model:
+  model_id: HuggingFaceTB/SmolVLM-256M-Instruct
+  is_vlm: true
+  dtype: bfloat16
+  device: cuda
+  trust_remote_code: true
+  attn_impl: flash_attention_2
+scoring:
+  seed: 123
+  normalize_by_length: false
+generation:
+  max_new_tokens: 16
+report:
+  output_dir: artifacts/nanoeval/mme/smolvlm-256m
+  summary_filename: summary.json
+  predictions_filename: predictions.jsonl
+  table_filename: metrics.csv
+  plot_filename: accuracy.png
+  save_predictions: true
+  save_table: true
+  save_plot: true
+dataset:
+  split: test
+  subset_size: null

--- a/eval/nanoeval/configs/textvqa_smolvlm.yaml
+++ b/eval/nanoeval/configs/textvqa_smolvlm.yaml
@@ -1,0 +1,26 @@
+# TextVQA validation evaluation with SmolVLM.
+task: textvqa
+model:
+  model_id: HuggingFaceTB/SmolVLM-256M-Instruct
+  is_vlm: true
+  dtype: bfloat16
+  device: cuda
+  trust_remote_code: true
+  attn_impl: flash_attention_2
+scoring:
+  seed: 123
+  normalize_by_length: false
+generation:
+  max_new_tokens: 32
+report:
+  output_dir: artifacts/nanoeval/textvqa/smolvlm-256m
+  summary_filename: summary.json
+  predictions_filename: predictions.jsonl
+  table_filename: metrics.csv
+  plot_filename: accuracy.png
+  save_predictions: true
+  save_table: true
+  save_plot: true
+dataset:
+  split: validation
+  subset_size: 512

--- a/eval/nanoeval/run_mme.py
+++ b/eval/nanoeval/run_mme.py
@@ -1,0 +1,143 @@
+"""MME yes/no evaluation with greedy generation."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from .common import SimpleModel, set_seed
+from .config import MMERunConfig, load_task_config
+from .reporting import ReportWriter
+
+_YES_TOKENS = {"yes", "yeah", "y", "true", "correct", "yep"}
+_NO_TOKENS = {"no", "nah", "n", "false", "incorrect", "nope"}
+_WORD_PATTERN = re.compile(r"[a-zA-Z]+")
+
+
+def _extract_yes_no(text: str) -> str | None:
+    """Return ``"yes"``/``"no"`` if the string contains a confident answer."""
+
+    lowered = text.lower()
+    for match in _WORD_PATTERN.findall(lowered):
+        if match in _YES_TOKENS:
+            return "yes"
+        if match in _NO_TOKENS:
+            return "no"
+    return None
+
+
+def _format_prompt(question: str) -> str:
+    return (
+        "You are a vision-language assistant. Answer the question with yes or no.\n"
+        f"Question: {question}\n"
+        "Answer:"
+    )
+
+
+def run(config: MMERunConfig) -> Dict[str, object]:
+    """Evaluate MME according to ``config`` and return summary metrics."""
+
+    set_seed(config.scoring.seed)
+    model = SimpleModel(config.model)
+
+    dataset = load_dataset("lmms-lab/MME", split=config.dataset.split)
+    if config.dataset.subset_size is not None:
+        dataset = dataset.select(range(min(config.dataset.subset_size, len(dataset))))
+
+    per_category = defaultdict(lambda: {"correct": 0, "total": 0})
+    rows: List[Dict[str, object]] = []
+
+    for example in tqdm(dataset, desc=f"mme:{config.dataset.split}"):
+        category = str(example.get("category", "unknown"))
+        question = str(example.get("question", ""))
+        gold_raw = str(example.get("answer", "")).strip().lower()
+        gold = "yes" if gold_raw.startswith("y") else "no"
+        image = example.get("image")
+        prompt = _format_prompt(question)
+        if model.processor is None:
+            completion = model.generate_text(
+                prompt, max_new_tokens=config.generation.max_new_tokens
+            )
+        else:
+            completion = model.generate_text(
+                prompt,
+                images=[image] if image is not None else None,
+                max_new_tokens=config.generation.max_new_tokens,
+            )
+        predicted_label = _extract_yes_no(completion) or "unknown"
+        is_correct = predicted_label == gold
+        per_category[category]["correct"] += int(is_correct)
+        per_category[category]["total"] += 1
+        rows.append(
+            {
+                "task": "mme",
+                "category": category,
+                "question": question,
+                "prediction": predicted_label,
+                "raw_prediction": completion,
+                "gold": gold,
+                "correct": bool(is_correct),
+            }
+        )
+
+    total_correct = sum(item["correct"] for item in per_category.values())
+    total_seen = sum(item["total"] for item in per_category.values())
+    accuracy = total_correct / max(1, total_seen)
+
+    per_category_accuracy = [
+        (category, counts["correct"] / max(1, counts["total"]))
+        for category, counts in sorted(per_category.items())
+    ]
+
+    writer = ReportWriter(config.report, title="MME yes/no accuracy")
+    writer.write_predictions(rows)
+    writer.write_summary(
+        {
+            "task": "mme",
+            "accuracy": accuracy,
+            "total_examples": total_seen,
+            "split": config.dataset.split,
+            "subset_size": config.dataset.subset_size,
+            "max_new_tokens": config.generation.max_new_tokens,
+            "seed": config.scoring.seed,
+            "model_id": config.model.model_id,
+            "per_category": {
+                category: {
+                    "accuracy": counts["correct"] / max(1, counts["total"]),
+                    "correct": counts["correct"],
+                    "total": counts["total"],
+                }
+                for category, counts in per_category.items()
+            },
+        }
+    )
+    writer.write_metrics_table(per_category_accuracy)
+    writer.plot_metrics(per_category_accuracy)
+
+    return {"accuracy": accuracy, "total_examples": total_seen, "per_category": dict(per_category)}
+
+
+def run_from_yaml(config_path: Path) -> Dict[str, object]:
+    cfg = load_task_config(config_path)
+    if not isinstance(cfg, MMERunConfig):
+        raise TypeError("MME runner received a configuration for a different task")
+    return run(cfg)
+
+
+def _main() -> None:
+    config_env = os.environ.get("NANOEVAL_CONFIG")
+    if config_env is None:
+        raise SystemExit("Set NANOEVAL_CONFIG to the path of an MME config YAML")
+    summary = run_from_yaml(Path(config_env))
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    _main()

--- a/eval/nanoeval/run_textvqa.py
+++ b/eval/nanoeval/run_textvqa.py
@@ -1,0 +1,160 @@
+"""TextVQA evaluation loop following the NanoEval philosophy."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Dict, List, Mapping, Sequence
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from .common import SimpleModel, set_seed
+from .config import TextVQARunConfig, load_task_config
+from .reporting import ReportWriter
+
+_ARTICLES = {"a", "an", "the"}
+_PUNCT_PATTERN = re.compile(r"[^a-z0-9\s]")
+
+
+def _normalize_answer(text: str) -> str:
+    """Lowercase, strip punctuation, and drop articles."""
+
+    lowered = text.lower().strip()
+    cleaned = _PUNCT_PATTERN.sub(" ", lowered)
+    tokens = [token for token in cleaned.split() if token not in _ARTICLES]
+    return " ".join(tokens)
+
+
+def _coerce_answers(raw: object) -> List[str]:
+    """Return the list of ground-truth answers for a TextVQA example."""
+
+    if raw is None:
+        return []
+    if isinstance(raw, Mapping):
+        candidate = raw.get("answer")
+        return [str(candidate)] if candidate is not None else []
+    answers: List[str] = []
+    for item in raw:  # type: ignore[assignment]
+        if isinstance(item, Mapping) and "answer" in item:
+            answers.append(str(item["answer"]))
+        else:
+            answers.append(str(item))
+    return answers
+
+
+def _score_prediction(prediction: str, answers: Sequence[str]) -> float:
+    """Compute official VQA accuracy using leave-one-out scoring."""
+
+    if not answers:
+        return 0.0
+    normalized_prediction = _normalize_answer(prediction)
+    normalized_answers = [_normalize_answer(answer) for answer in answers]
+    per_answer_scores: List[float] = []
+    for index in range(len(normalized_answers)):
+        others = normalized_answers[:index] + normalized_answers[index + 1 :]
+        matches = sum(other == normalized_prediction for other in others)
+        per_answer_scores.append(min(matches / 3.0, 1.0))
+    return sum(per_answer_scores) / len(per_answer_scores)
+
+
+def _format_prompt(question: str) -> str:
+    return (
+        "You are a helpful assistant that answers questions about images.\n"
+        f"Question: {question}\n"
+        "Answer:"
+    )
+
+
+def run(config: TextVQARunConfig) -> Dict[str, object]:
+    """Evaluate TextVQA according to ``config`` and return the summary payload."""
+
+    set_seed(config.scoring.seed)
+
+    model = SimpleModel(config.model)
+    dataset = load_dataset("lmms-lab/textvqa", split=config.dataset.split)
+    if config.dataset.subset_size is not None:
+        dataset = dataset.select(range(min(config.dataset.subset_size, len(dataset))))
+
+    rows: List[Dict[str, object]] = []
+    total_score = 0.0
+
+    for example in tqdm(dataset, desc=f"textvqa:{config.dataset.split}"):
+        question = str(example.get("question", ""))
+        answers = _coerce_answers(example.get("answers"))
+        image = example.get("image")
+        prompt = _format_prompt(question)
+        if model.processor is None:
+            prediction = model.generate_text(
+                prompt, max_new_tokens=config.generation.max_new_tokens
+            )
+        else:
+            prediction = model.generate_text(
+                prompt,
+                images=[image] if image is not None else None,
+                max_new_tokens=config.generation.max_new_tokens,
+            )
+        score = _score_prediction(prediction, answers)
+        total_score += score
+        question_id = (
+            example.get("question_id")
+            or example.get("questionId")
+            or example.get("questionid")
+            or example.get("qid")
+        )
+        image_id = example.get("image_id") or example.get("imageId")
+        rows.append(
+            {
+                "task": "textvqa",
+                "question_id": question_id,
+                "image_id": image_id,
+                "question": question,
+                "prediction": prediction,
+                "normalized_prediction": _normalize_answer(prediction),
+                "answers": answers,
+                "score": score,
+            }
+        )
+
+    total_examples = len(rows)
+    accuracy = total_score / max(1, total_examples)
+
+    writer = ReportWriter(config.report, title="TextVQA accuracy")
+    writer.write_predictions(rows)
+    writer.write_summary(
+        {
+            "task": "textvqa",
+            "accuracy": accuracy,
+            "total_examples": total_examples,
+            "split": config.dataset.split,
+            "subset_size": config.dataset.subset_size,
+            "max_new_tokens": config.generation.max_new_tokens,
+            "seed": config.scoring.seed,
+            "model_id": config.model.model_id,
+        }
+    )
+    writer.write_metrics_table([(config.dataset.split, accuracy)])
+    writer.plot_metrics([(config.dataset.split, accuracy)])
+
+    return {"accuracy": accuracy, "total_examples": total_examples}
+
+
+def run_from_yaml(config_path: Path) -> Dict[str, object]:
+    cfg = load_task_config(config_path)
+    if not isinstance(cfg, TextVQARunConfig):
+        raise TypeError("TextVQA runner received a configuration for a different task")
+    return run(cfg)
+
+
+def _main() -> None:
+    config_env = os.environ.get("NANOEVAL_CONFIG")
+    if config_env is None:
+        raise SystemExit("Set NANOEVAL_CONFIG to the path of a TextVQA config YAML")
+    summary = run_from_yaml(Path(config_env))
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    _main()

--- a/eval/nanoeval/suite.py
+++ b/eval/nanoeval/suite.py
@@ -75,10 +75,18 @@ def _run_task(task: TaskConfig) -> Dict[str, object]:
         from .run_hellaswag import run as run_hellaswag
 
         summary = run_hellaswag(task)  # type: ignore[arg-type]
-    else:
+    elif task.task == "mmmu_pro":
         from .run_mmmu_pro import run as run_mmmu_pro
 
         summary = run_mmmu_pro(task)  # type: ignore[arg-type]
+    elif task.task == "textvqa":
+        from .run_textvqa import run as run_textvqa
+
+        summary = run_textvqa(task)  # type: ignore[arg-type]
+    else:
+        from .run_mme import run as run_mme
+
+        summary = run_mme(task)  # type: ignore[arg-type]
     return {"task": task.task, **summary}
 
 

--- a/test/test_nanoeval_common.py
+++ b/test/test_nanoeval_common.py
@@ -33,25 +33,42 @@ class _DummyTextTokenizer:
             " correct": [1, 2],
             " wrong": [3, 4],
         }
+        self.reverse = {1: "c", 2: "orrect", 3: "w", 4: "rong"}
+        self.pad_token_id = 0
+        self.eos_token_id = 99
 
     def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
         return list(self.mapping[text])
+
+    def decode(self, tokens: list[int], skip_special_tokens: bool = True) -> str:
+        return "".join(self.reverse.get(token, "") for token in tokens)
 
 
 class _DummyTextModel:
     def __call__(self, *, input_ids: torch.Tensor):
         tokens = input_ids.tolist()[0]
+        seq_len = len(tokens)
+        vocab_size = max(max(tokens) + 1, 6)
+        logits = torch.zeros((1, seq_len, vocab_size), dtype=torch.float32)
         if tokens[1] == 1:  # option "correct"
-            logits = torch.tensor(
-                [[[5.0, 5.0, 5.0, 0.0, 0.0], [5.0, 5.0, 5.0, 0.0, 0.0]]],
-                dtype=torch.float32,
-            )
+            weight = 5.0
         else:  # option "wrong"
-            logits = torch.tensor(
-                [[[0.0, 0.0, 0.0, 5.0, 5.0], [0.0, 0.0, 0.0, 5.0, 5.0]]],
-                dtype=torch.float32,
-            )
+            weight = -5.0
+        for index, token in enumerate(tokens[1:], start=0):
+            logits[0, index, token] = weight
         return SimpleNamespace(logits=logits)
+
+    def generate(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        max_new_tokens: int,
+        do_sample: bool,
+        pad_token_id: int | None,
+    ) -> torch.Tensor:
+        suffix = torch.tensor([[1, 2]], dtype=torch.long)
+        return torch.cat([input_ids, suffix[:, : max_new_tokens]], dim=1)
 
 
 class _DummyProcessor:
@@ -70,21 +87,36 @@ class _DummyProcessor:
         }
         return _DummyEncoding(mapping[text])
 
+    @property
+    def tokenizer(self) -> _DummyTextTokenizer:  # type: ignore[override]
+        return _DummyTextTokenizer()
+
 
 class _DummyVLMModel:
     def __call__(self, *, input_ids: torch.Tensor):
         tokens = input_ids.tolist()[0]
+        seq_len = len(tokens)
+        vocab_size = max(max(tokens) + 1, 6)
+        logits = torch.zeros((1, seq_len, vocab_size), dtype=torch.float32)
         if tokens[2] == 1:  # option "cat"
-            logits = torch.tensor(
-                [[[5.0, 5.0, 5.0, 0.0, 0.0], [5.0, 5.0, 5.0, 0.0, 0.0], [5.0, 5.0, 5.0, 0.0, 0.0]]],
-                dtype=torch.float32,
-            )
+            weight = 5.0
         else:  # option "dog"
-            logits = torch.tensor(
-                [[[0.0, 0.0, 0.0, 5.0, 5.0], [0.0, 0.0, 0.0, 5.0, 5.0], [0.0, 0.0, 0.0, 5.0, 5.0]]],
-                dtype=torch.float32,
-            )
+            weight = -5.0
+        for index, token in enumerate(tokens[1:], start=0):
+            logits[0, index, token] = weight
         return SimpleNamespace(logits=logits)
+
+    def generate(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        max_new_tokens: int,
+        do_sample: bool,
+        pad_token_id: int | None,
+    ) -> torch.Tensor:
+        suffix = torch.tensor([[1, 2]], dtype=torch.long)
+        return torch.cat([input_ids, suffix[:, : max_new_tokens]], dim=1)
 
 
 def _build_simple_text_model() -> SimpleModel:
@@ -118,6 +150,18 @@ def test_rank_log_likelihood_multimodal_prefers_high_prob_option():
         messages, images=(), options=["cat", "dog"]
     )
     assert result == 0
+
+
+def test_generate_text_for_text_model_uses_greedy_suffix():
+    model = _build_simple_text_model()
+    result = model.generate_text("prompt", max_new_tokens=2)
+    assert result == "correct"
+
+
+def test_generate_text_for_vlm_accepts_string_prompt():
+    model = _build_simple_vlm_model()
+    result = model.generate_text("prompt", images=[object()], max_new_tokens=1)
+    assert result == "c"
 
 
 def test_set_seed_cpu_only(monkeypatch):

--- a/test/test_textvqa_mme_utils.py
+++ b/test/test_textvqa_mme_utils.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from eval.nanoeval.config import build_task_config  # noqa: E402
+from eval.nanoeval.run_mme import _extract_yes_no  # noqa: E402
+from eval.nanoeval.run_textvqa import _coerce_answers, _normalize_answer, _score_prediction  # noqa: E402
+
+
+def test_normalize_answer_strips_articles_and_punctuation():
+    assert _normalize_answer("The,  Blue! Car?") == "blue car"
+
+
+def test_score_prediction_matches_official_rule():
+    answers = ["yes"] * 7 + ["no"] * 3
+    assert pytest.approx(_score_prediction("Yes", answers), rel=1e-6) == 1.0
+    assert pytest.approx(_score_prediction("no", answers), rel=1e-6) == pytest.approx(0.9, rel=1e-6)
+
+
+def test_coerce_answers_handles_dict_entries():
+    payload = [{"answer": "ten"}, {"answer": "ten"}, "TEN"]
+    assert _coerce_answers(payload) == ["ten", "ten", "TEN"]
+
+
+def test_extract_yes_no_prefers_first_confident_token():
+    assert _extract_yes_no("Absolutely yes, no doubt.") == "yes"
+    assert _extract_yes_no("Nope, sorry!") == "no"
+    assert _extract_yes_no("Maybe") is None
+
+
+def test_build_task_config_for_textvqa_infers_generation_defaults():
+    cfg = build_task_config({
+        "task": "textvqa",
+        "model": {"model_id": "dummy", "is_vlm": True},
+    })
+    assert cfg.task == "textvqa"
+    assert cfg.generation.max_new_tokens == 32
+
+
+def test_build_task_config_for_mme_sets_subset_defaults():
+    cfg = build_task_config({
+        "task": "mme",
+        "model": {"model_id": "dummy", "is_vlm": True},
+        "dataset": {"split": "test", "subset_size": 5},
+        "generation": {"max_new_tokens": 8},
+    })
+    assert cfg.task == "mme"
+    assert cfg.dataset.subset_size == 5
+    assert cfg.generation.max_new_tokens == 8


### PR DESCRIPTION
## Summary
- add a greedy `generate_text` helper to `SimpleModel` that works for text-only and multimodal models
- introduce TextVQA and MME evaluation runners with example configs and documentation updates
- expand nanoeval configuration helpers and tests to cover the new tasks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e493c69a24832b9eaf632d809fdc70